### PR TITLE
test: Always allow greater patch-version of SDL2

### DIFF
--- a/sdl2/test/sdlmixer_test.py
+++ b/sdl2/test/sdlmixer_test.py
@@ -27,7 +27,7 @@ class SDLMixerTest(unittest.TestCase):
         self.assertIsInstance(v.contents, version.SDL_version)
         self.assertEqual(v.contents.major, 2)
         self.assertEqual(v.contents.minor, 0)
-        self.assertEqual(v.contents.patch, 2)
+        self.assertGreaterEqual(v.contents.patch, 2)
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/sdl2/test/version_test.py
+++ b/sdl2/test/version_test.py
@@ -25,7 +25,7 @@ class SDLVersionTest(unittest.TestCase):
         self.assertEqual(type(v), version.SDL_version)
         self.assertEqual(v.major, 2)
         self.assertEqual(v.minor, 0)
-        self.assertEqual(v.patch, 7)
+        self.assertGreaterEqual(v.patch, 7)
 
     def test_SDL_VERSIONNUM(self):
         self.assertEqual(version.SDL_VERSIONNUM(1, 2, 3), 1203)


### PR DESCRIPTION
Similarly to sdlimage_test, allow newer patch-version of other SDL2
libraries. There is no technical reason to prevent people from upgrading
libsdl2 while having old PySDL2 installed, and there is no reason to
make tests fail every time libsdl2 happens to be upgraded.

Closes: https://github.com/marcusva/py-sdl2/issues/115