### PR TITLE
test: Skip tests on missing subsystems gracefully

### DIFF
--- a/sdl2/test/audio_test.py
+++ b/sdl2/test/audio_test.py
@@ -144,10 +144,15 @@ class SDLAudioTest(unittest.TestCase):
         pass
 
     def test_SDL_GetNumAudioDrivers(self):
+        if SDL_InitSubSystem(SDL_INIT_AUDIO) != 0:
+            self.skipTest('Audio subsystem not supported')
         count = audio.SDL_GetNumAudioDrivers()
         self.assertGreaterEqual(count, 1)
+        SDL_QuitSubSystem(SDL_INIT_AUDIO)
 
     def test_SDL_GetAudioDriver(self):
+        if SDL_InitSubSystem(SDL_INIT_AUDIO) != 0:
+            self.skipTest('Audio subsystem not supported')
         founddummy = False
         drivercount = audio.SDL_GetNumAudioDrivers()
         for index in range(drivercount):
@@ -163,28 +168,29 @@ class SDLAudioTest(unittest.TestCase):
                           audio.SDL_GetAudioDriver, "Test")
         self.assertRaises((ctypes.ArgumentError, TypeError),
                           audio.SDL_GetAudioDriver, None)
+        SDL_QuitSubSystem(SDL_INIT_AUDIO)
 
     def test_SDL_GetCurrentAudioDriver(self):
+        if SDL_InitSubSystem(SDL_INIT_AUDIO) != 0:
+            self.skipTest('Audio subsystem not supported')
         success = 0
         for index in range(audio.SDL_GetNumAudioDrivers()):
             drivername = audio.SDL_GetAudioDriver(index)
             os.environ["SDL_AUDIODRIVER"] = drivername.decode("utf-8")
-            # Certain drivers fail without bringing up the correct
-            # return value, such as the esd, if it is not running.
-            SDL_InitSubSystem(SDL_INIT_AUDIO)
             driver = audio.SDL_GetCurrentAudioDriver()
             # Do not handle wrong return values.
             if driver is not None:
                 self.assertEqual(drivername, driver)
                 success += 1
-            SDL_QuitSubSystem(SDL_INIT_AUDIO)
         self.assertGreaterEqual(success, 1,
                                 "Could not initialize any sound driver")
+        SDL_QuitSubSystem(SDL_INIT_AUDIO)
 
     @unittest.skip("SDL_AudioCallback is not retained in SDL_AudioSpec")
     def test_SDL_OpenAudio(self):
         os.environ["SDL_AUDIODRIVER"] = "dummy"
-        SDL_InitSubSystem(SDL_INIT_AUDIO)
+        if SDL_InitSubSystem(SDL_INIT_AUDIO) != 0:
+            self.skipTest('Audio subsystem not supported')
         reqspec = audio.SDL_AudioSpec(44100, audio.AUDIO_U16SYS, 2, 8192,
                                       self.audiocallback, None)
         spec = audio.SDL_AudioSpec(0, 0, 0, 0)
@@ -198,7 +204,8 @@ class SDLAudioTest(unittest.TestCase):
 
     def test_SDL_GetNumAudioDevices(self):
         os.environ["SDL_AUDIODRIVER"] = "dummy"
-        SDL_InitSubSystem(SDL_INIT_AUDIO)
+        if SDL_InitSubSystem(SDL_INIT_AUDIO) != 0:
+            self.skipTest('Audio subsystem not supported')
         outnum = audio.SDL_GetNumAudioDevices(False)
         self.assertGreaterEqual(outnum, 1)
         innum = audio.SDL_GetNumAudioDevices(True)
@@ -207,7 +214,8 @@ class SDLAudioTest(unittest.TestCase):
 
     def test_SDL_GetAudioDeviceName(self):
         os.environ["SDL_AUDIODRIVER"] = "dummy"
-        SDL_InitSubSystem(SDL_INIT_AUDIO)
+        if SDL_InitSubSystem(SDL_INIT_AUDIO) != 0:
+            self.skipTest('Audio subsystem not supported')
         outnum = audio.SDL_GetNumAudioDevices(False)
         for x in range(outnum):
             name = audio.SDL_GetAudioDeviceName(x, False)
@@ -226,7 +234,8 @@ class SDLAudioTest(unittest.TestCase):
     @unittest.skip("SDL_AudioCallback is not retained in SDL_AudioSpec")
     def test_SDL_OpenCloseAudioDevice(self):
         os.environ["SDL_AUDIODRIVER"] = "dummy"
-        SDL_InitSubSystem(SDL_INIT_AUDIO)
+        if SDL_InitSubSystem(SDL_INIT_AUDIO) != 0:
+            self.skipTest('Audio subsystem not supported')
         reqspec = audio.SDL_AudioSpec(44100, audio.AUDIO_U16SYS, 2, 8192,
                                       self.audiocallback, None)
         outnum = audio.SDL_GetNumAudioDevices(0)

--- a/sdl2/test/blendmode_test.py
+++ b/sdl2/test/blendmode_test.py
@@ -9,7 +9,8 @@ class SDLBlendmodeTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        SDL_Init(SDL_INIT_VIDEO)
+        if SDL_Init(SDL_INIT_VIDEO) != 0:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/gamecontroller_test.py
+++ b/sdl2/test/gamecontroller_test.py
@@ -9,7 +9,8 @@ class SDLGamecontrollerTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        SDL_Init(SDL_INIT_JOYSTICK)
+        if SDL_Init(SDL_INIT_JOYSTICK) != 0:
+            raise unittest.SkipTest('Joystick subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/joystick_test.py
+++ b/sdl2/test/joystick_test.py
@@ -10,7 +10,8 @@ class SDLJoystickTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        SDL_Init(SDL_INIT_JOYSTICK)
+        if SDL_Init(SDL_INIT_JOYSTICK) != 0:
+            raise unittest.SkipTest('Joystick subsystem not supported')
         cls.jcount = joystick.SDL_NumJoysticks()
 
     @classmethod

--- a/sdl2/test/keyboard_test.py
+++ b/sdl2/test/keyboard_test.py
@@ -12,7 +12,8 @@ class SDLKeyboardTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        SDL_Init(SDL_INIT_VIDEO)
+        if SDL_Init(SDL_INIT_VIDEO) != 0:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/render_test.py
+++ b/sdl2/test/render_test.py
@@ -24,6 +24,8 @@ class SDLRenderTest(unittest.TestCase):
         cls._RENDERFLAGS = render.SDL_RENDERER_ACCELERATED
         SDL_Init(SDL_INIT_EVERYTHING)
         driver = video.SDL_GetCurrentVideoDriver()
+        if driver is None:
+            raise unittest.SkipTest('Video subsystem not supported')
         if driver == b"dummy":
             cls._RENDERFLAGS = render.SDL_RENDERER_SOFTWARE
 

--- a/sdl2/test/sdl2ext_draw_test.py
+++ b/sdl2/test/sdl2ext_draw_test.py
@@ -9,7 +9,10 @@ class SDL2ExtDrawTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/sdl2ext_font_test.py
+++ b/sdl2/test/sdl2ext_font_test.py
@@ -22,7 +22,10 @@ class SDL2ExtFontTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/sdl2ext_gui_test.py
+++ b/sdl2/test/sdl2ext_gui_test.py
@@ -8,7 +8,10 @@ class SDL2ExtGUITest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/sdl2ext_image_test.py
+++ b/sdl2/test/sdl2ext_image_test.py
@@ -32,7 +32,10 @@ class SDL2ExtImageTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/sdl2ext_pixelaccess_test.py
+++ b/sdl2/test/sdl2ext_pixelaccess_test.py
@@ -14,7 +14,10 @@ class SDL2ExtPixelAccessTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/sdl2ext_sprite_test.py
+++ b/sdl2/test/sdl2ext_sprite_test.py
@@ -35,7 +35,10 @@ class SDL2ExtSpriteTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/sdl2ext_test.py
+++ b/sdl2/test/sdl2ext_test.py
@@ -9,7 +9,10 @@ class SDL2ExtTest(unittest.TestCase):
     __tags__ = ["sdl", "sdl2ext"]
 
     def test_init_quit(self):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
         self.assertEqual(SDL_WasInit(SDL_INIT_VIDEO), SDL_INIT_VIDEO)
         sdl2ext.quit()
         self.assertNotEqual(SDL_WasInit(SDL_INIT_VIDEO), SDL_INIT_VIDEO)
@@ -25,7 +28,10 @@ class SDL2ExtTest(unittest.TestCase):
         self.assertNotEqual(SDL_WasInit(SDL_INIT_VIDEO), SDL_INIT_VIDEO)
 
     def test_get_events(self):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
         SDL_FlushEvent(SDL_FIRSTEVENT, SDL_LASTEVENT)
         for x in range(10):
             event = SDL_Event()
@@ -39,7 +45,10 @@ class SDL2ExtTest(unittest.TestCase):
             self.assertEqual(ev.type, (SDL_USEREVENT + 1))
 
     def test_get_events_issue_6(self):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
         SDL_FlushEvent(SDL_FIRSTEVENT, SDL_LASTEVENT)
         for x in range(12):
             event = SDL_Event()

--- a/sdl2/test/sdl2ext_window_test.py
+++ b/sdl2/test/sdl2ext_window_test.py
@@ -9,7 +9,10 @@ class SDL2ExtWindowTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        sdl2ext.init()
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/sdl_test.py
+++ b/sdl2/test/sdl_test.py
@@ -17,28 +17,32 @@ class SDLTest(unittest.TestCase):
 
     def test_SDL_INIT_TIMER(self):
         ret = SDL_Init(SDL_INIT_TIMER)
-        self.assertEqual(ret, 0, SDL_GetError())
+        if ret != 0:
+            self.skipTest('Timer subsystem not supported')
         ret = SDL_WasInit(SDL_INIT_TIMER)
         self.assertEqual(ret, SDL_INIT_TIMER)
         SDL_QuitSubSystem(SDL_INIT_TIMER)
 
     def test_SDL_INIT_AUDIO(self):
         ret = SDL_Init(SDL_INIT_AUDIO)
-        self.assertEqual(ret, 0, SDL_GetError())
+        if ret != 0:
+            self.skipTest('Audio subsystem not supported')
         ret = SDL_WasInit(SDL_INIT_AUDIO)
         self.assertEqual(ret, SDL_INIT_AUDIO)
         SDL_QuitSubSystem(SDL_INIT_AUDIO)
 
     def test_SDL_INIT_VIDEO(self):
         ret = SDL_Init(SDL_INIT_VIDEO)
-        self.assertEqual(ret, 0, SDL_GetError())
+        if ret != 0:
+            self.skipTest('Video subsystem not supported')
         ret = SDL_WasInit(SDL_INIT_VIDEO)
         self.assertEqual(ret, SDL_INIT_VIDEO)
         SDL_QuitSubSystem(SDL_INIT_VIDEO)
 
     def test_SDL_INIT_JOYSTICK(self):
         ret = SDL_Init(SDL_INIT_JOYSTICK)
-        self.assertEqual(ret, 0, SDL_GetError())
+        if ret != 0:
+            self.skipTest('Joystick subsystem not supported')
         ret = SDL_WasInit(SDL_INIT_JOYSTICK)
         self.assertEqual(ret, SDL_INIT_JOYSTICK)
         SDL_QuitSubSystem(SDL_INIT_JOYSTICK)
@@ -47,7 +51,8 @@ class SDLTest(unittest.TestCase):
                      "FreeBSD des not support haptic input yet")
     def test_SDL_INIT_HAPTIC(self):
         ret = SDL_Init(SDL_INIT_HAPTIC)
-        self.assertEqual(ret, 0, SDL_GetError())
+        if ret != 0:
+            self.skipTest('Haptic subsystem not supported')
         ret = SDL_WasInit(SDL_INIT_HAPTIC)
         self.assertEqual(ret, SDL_INIT_HAPTIC)
         SDL_QuitSubSystem(SDL_INIT_HAPTIC)

--- a/sdl2/test/sdlgfx_test.py
+++ b/sdl2/test/sdlgfx_test.py
@@ -16,7 +16,8 @@ class SDLTTFTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        SDL_Init(SDL_INIT_VIDEO)
+        if SDL_Init(SDL_INIT_VIDEO) != 0:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/shape_test.py
+++ b/sdl2/test/shape_test.py
@@ -11,6 +11,8 @@ class SDLShapeTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         SDL_Init(SDL_INIT_EVERYTHING)
+        if video.SDL_GetCurrentVideoDriver() is None:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/syswm_test.py
+++ b/sdl2/test/syswm_test.py
@@ -10,7 +10,8 @@ class SDLSysWMTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        video.SDL_VideoInit(None)
+        if video.SDL_VideoInit(None) != 0:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/timer_test.py
+++ b/sdl2/test/timer_test.py
@@ -16,7 +16,8 @@ class SDLTimerTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        SDL_Init(SDL_INIT_TIMER)
+        if SDL_Init(SDL_INIT_TIMER) != 0:
+            raise unittest.SkipTest('Timer subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/video_test.py
+++ b/sdl2/test/video_test.py
@@ -32,7 +32,8 @@ class SDLVideoTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        video.SDL_VideoInit(None)
+        if video.SDL_VideoInit(None) != 0:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):

--- a/sdl2/test/vulkan_test.py
+++ b/sdl2/test/vulkan_test.py
@@ -7,7 +7,8 @@ class SDLVulkanTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        SDL_Init(SDL_INIT_VIDEO)
+        if SDL_Init(SDL_INIT_VIDEO) != 0:
+            raise unittest.SkipTest('Video subsystem not supported')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
All of the SDL2 subsystems are optional. Add an appropriate logic to
skip tests if SDL2 is built without them.

While missing audio and video subsystems are rather unlikely,
e.g. the haptic subsystem is rarely actually necessary (especially with
no compatible hardware). However, supporting every (or least most of)
missing subsystems should be cleaner and not cause any harm.

While technically SDL2_Init() and related functions can fail with other
errors, it is rather unlikely that the tests would be able to trigger
any real problem with the code that would result in non-zero return
value of this function.

Closes: https://github.com/marcusva/py-sdl2/issues/116