### PR TITLE
Check for window attribute on Window object close

### DIFF
--- a/sdl2/ext/window.py
+++ b/sdl2/ext/window.py
@@ -119,7 +119,7 @@ class Window(object):
     def close(self):
         """Closes the window, implicitly destroying the underlying SDL2
         window."""
-        if self.window != None:
+        if hasattr(self, "window") and self.window != None:
             video.SDL_DestroyWindow(self.window)
             self.window = None
 


### PR DESCRIPTION
Eliminates an exception when a Window is destroyed but the call to
SDL_CreateWindow has not yet happened.