### PR TITLE
Allow .framework DLLs on macOS

### DIFF
--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -12,11 +12,11 @@ def _findlib(libnames, path=None):
     """."""
     platform = sys.platform
     if platform in ("win32",):
-        pattern = "%s.dll"
+        patterns = ["{0}.dll"]
     elif platform == "darwin":
-        pattern = "lib%s.dylib"
+        patterns = ["lib{0}.dylib", "{0}.framework/{0}"]
     else:
-        pattern = "lib%s.so"
+        patterns = ["lib{0}.so"]
     searchfor = libnames
     if type(libnames) is dict:
         # different library names for the platforms
@@ -27,9 +27,10 @@ def _findlib(libnames, path=None):
     if path:
         for libname in searchfor:
             for subpath in str.split(path, os.pathsep):
-                dllfile = os.path.join(subpath, pattern % libname)
-                if os.path.exists(dllfile):
-                    results.append(dllfile)
+                for pattern in patterns:
+                    dllfile = os.path.join(subpath, pattern.format(libname))
+                    if os.path.exists(dllfile):
+                        results.append(dllfile)
     for libname in searchfor:
         dllfile = find_library(libname)
         if dllfile:

--- a/sdl2/sdlmixer.py
+++ b/sdl2/sdlmixer.py
@@ -27,7 +27,7 @@ __all__ = ["get_dll_file", "SDL_MIXER_MAJOR_VERSION", "SDL_MIXER_MINOR_VERSION",
            "Mix_LoadMUSType_RW", "Mix_QuickLoad_WAV", "Mix_QuickLoad_RAW",
            "Mix_FreeChunk", "Mix_FreeMusic", "Mix_GetNumChunkDecoders",
            "Mix_GetChunkDecoder", "Mix_GetNumMusicDecoders",
-           "Mix_HasChunkDecoder", "Mix_HasMusicDecoder",
+           "Mix_HasChunkDecoder", #"Mix_HasMusicDecoder",
            "Mix_GetMusicDecoder", "Mix_GetMusicType", "mix_func",
            "Mix_SetPostMix", "Mix_HookMusic", "music_finished",
            "Mix_HookMusicFinished", "Mix_GetMusicHookData", "channel_finished",
@@ -146,7 +146,7 @@ Mix_GetChunkDecoder = _bind("Mix_GetChunkDecoder", [c_int], c_char_p)
 Mix_HasChunkDecoder = _bind("Mix_HasChunkDecoder", [c_char_p], SDL_bool)
 Mix_GetNumMusicDecoders = _bind("Mix_GetNumMusicDecoders", None, c_int)
 Mix_GetMusicDecoder = _bind("Mix_GetMusicDecoder", [c_int], c_char_p)
-Mix_HasMusicDecoder = _bind("Mix_HasMusicDecoder", [c_char_p], SDL_bool)
+#Mix_HasMusicDecoder = _bind("Mix_HasMusicDecoder", [c_char_p], SDL_bool) # not actually implemented in SDL_mixer
 Mix_GetMusicType = _bind("Mix_GetMusicType", [POINTER(Mix_Music)], Mix_MusicType)
 mix_func = CFUNCTYPE(None, c_void_p, POINTER(Uint8), c_int)
 Mix_SetPostMix = _bind("Mix_SetPostMix", [mix_func, c_void_p])


### PR DESCRIPTION
The pre-built SDL2 binaries for macOS on the official website are all packaged in .framework format. However, PySDL2 currently only looks for SDL2 DLLs in .dylib format, meaning that if you download the official frameworks and try to point `PYSDL2_DLL_PATH` towards them, it won't be able to find them.

This patch fixes this, and lays the groundwork for having a separate 'pysdl2-dlls wheel' that contains the official pre-built SDL2 + extras runtime libraries which would solve #78 (I currently have a script/package to create such a wheel for macOS and it seems to work well using this fix!)