### PR TITLE
removed redundant 'in' expr

### DIFF
--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -11,7 +11,7 @@ __all__ = ["DLL", "nullfunc"]
 def _findlib(libnames, path=None):
     """."""
     platform = sys.platform
-    if platform in ("win32",):
+    if platform == "win32":
         pattern = "%s.dll"
     elif platform == "darwin":
         pattern = "lib%s.dylib"


### PR DESCRIPTION
The code on line 14
```python
if platform in ("win32",):
```
has redundant `in` expression. Change it into `==` might be better.
