### PR TITLE
Fixes #33: Document differences between init functions

### DIFF
--- a/doc/modules/sdl2ext_common.rst
+++ b/doc/modules/sdl2ext_common.rst
@@ -2,7 +2,12 @@
 
 Initialization routines
 =======================
-TODO
+
+:func:`init()` simply calls :func:`SDL_Init()` to initialize only the video
+subsystem. If the call fails, :exc:`SDLError` is raised. See
+:ref:`pygamers_pygame` for a comparison between this function and
+:func:`pygame.init()`.
+
 
 API
 ---

--- a/doc/tutorial/pygamers.rst
+++ b/doc/tutorial/pygamers.rst
@@ -12,7 +12,6 @@ within PySDL2.
 
    More details, examples, etc.
 
-
 Technical differences
 ---------------------
 Pygame is implemented as a mixture of Python, C and Assembler code,
@@ -22,6 +21,8 @@ with the C interfaces of 3rd party libraries.
 
 API differences
 ---------------
+
+.. _pygamers_pygame:
 
 pygame
 ^^^^^^
@@ -39,6 +40,10 @@ pygame                  sdl2
 ``encode_string()``     No equivalent planned
 ``encode_file_path()``  No equivalent planned
 ======================= =================================================
+
+:func:`sdl2.ext.init()` initializes only the video subsystem. By comparison,
+:func:`pygame.init()` initializes all Pygame submodules (which includes
+initializing other SDL subsystems).
 
 pygame.cdrom
 ^^^^^^^^^^^^


### PR DESCRIPTION
- Looked at the `sdl2.ext.init()` function and compared it with `pygame.init()` in the Pygame sources
- Added comparison between `sdl2.ext.init()` and `SDL_Init()` to Initialization Routines page
- Added comparison between `sdl2.ext.init()` and `pygame.init()` to the Pygamers page
- Built the docs locally and made sure no links are broken