### PR TITLE
Fix Python segfault with Joystick/Gamepad GUID functions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ environment:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "pip install -U pip"
+  - "python -m pip install -U pip"
   - "python .ci/getsdl2.py"
   - "set PYSDL2_DLL_PATH=C:\\projects\\py-sdl2\\dlls"
   - "pip install -U numpy pytest"

--- a/sdl2/gamecontroller.py
+++ b/sdl2/gamecontroller.py
@@ -1,7 +1,9 @@
-from ctypes import Structure, Union, c_int, c_char_p, c_void_p, POINTER
+from ctypes import Structure, Union, c_int, c_char_p, c_void_p, POINTER, \
+    create_string_buffer
 from .dll import _bind
 from .stdinc import SDL_bool, Sint16, Uint16, Uint8
-from .joystick import SDL_JoystickGUID, SDL_Joystick, SDL_JoystickID
+from .joystick import SDL_JoystickGUID, SDL_Joystick, SDL_JoystickID, \
+    SDL_JoystickGetGUIDString
 from .rwops import SDL_RWops, SDL_RWFromFile
 
 
@@ -60,7 +62,6 @@ class SDL_GameControllerButtonBind(Structure):
     _fields_ = [("bindType", SDL_GameControllerBindType), ("value", _gcvalue)]
 
 SDL_GameControllerAddMapping = _bind("SDL_GameControllerAddMapping", [c_char_p], c_int)
-SDL_GameControllerMappingForGUID = _bind("SDL_GameControllerMappingForGUID", [SDL_JoystickGUID], c_char_p)
 SDL_GameControllerMapping = _bind("SDL_GameControllerMapping", [POINTER(SDL_GameController)], c_char_p)
 SDL_IsGameController = _bind("SDL_IsGameController", [c_int], SDL_bool)
 SDL_GameControllerNameForIndex = _bind("SDL_GameControllerNameForIndex", [c_int], c_char_p)
@@ -114,3 +115,19 @@ SDL_GameControllerGetProduct = _bind("SDL_GameControllerGetProduct", [POINTER(SD
 SDL_GameControllerGetProductVersion = _bind("SDL_GameControllerGetProductVersion", [POINTER(SDL_GameController)], Uint16, added='2.0.6')
 SDL_GameControllerNumMappings = _bind("SDL_GameControllerNumMappings", None, c_int, added='2.0.6')
 SDL_GameControllerMappingForIndex = _bind("SDL_GameControllerMappingForIndex", [c_int], c_char_p, added='2.0.6')
+
+
+#SDL_GameControllerMappingForGUID = _bind("SDL_GameControllerMappingForGUID", [SDL_JoystickGUID], c_char_p)
+def SDL_GameControllerMappingForGUID(guid):
+    # Reimplemented in Python due to crash-causing ctypes bug (fixed in 3.8)
+    buff = create_string_buffer(33)
+    SDL_JoystickGetGUIDString(guid, buff, 33) # Get GUID string
+    guid_str = buff.value
+    # Iterate over controller mappings and look for a GUID match
+    # Note: iterates in reverse, so user-defined mappings are checked first
+    num = SDL_GameControllerNumMappings()
+    for i in range(num - 1, -1, -1): 
+        m = SDL_GameControllerMappingForIndex(i)
+        if m.split(b',')[0] == guid_str:
+            return m
+    return None

--- a/sdl2/joystick.py
+++ b/sdl2/joystick.py
@@ -71,7 +71,6 @@ SDL_JoystickOpen = _bind("SDL_JoystickOpen", [c_int], POINTER(SDL_Joystick))
 SDL_JoystickName = _bind("SDL_JoystickName", [POINTER(SDL_Joystick)], c_char_p)
 SDL_JoystickGetDeviceGUID = _bind("SDL_JoystickGetDeviceGUID", [c_int], SDL_JoystickGUID)
 SDL_JoystickGetGUID = _bind("SDL_JoystickGetGUID", [POINTER(SDL_Joystick)], SDL_JoystickGUID)
-SDL_JoystickGetGUIDString = _bind("SDL_JoystickGetGUIDString", [SDL_JoystickGUID, c_char_p, c_int])
 SDL_JoystickGetGUIDFromString = _bind("SDL_JoystickGetGUIDFromString", [c_char_p], SDL_JoystickGUID)
 SDL_JoystickGetAttached = _bind("SDL_JoystickGetAttached", [POINTER(SDL_Joystick)], SDL_bool)
 SDL_JoystickInstanceID = _bind("SDL_JoystickInstanceID", [POINTER(SDL_Joystick)], SDL_JoystickID)
@@ -109,3 +108,12 @@ SDL_JoystickGetDeviceType = _bind("SDL_JoystickGetDeviceType", [c_int], SDL_Joys
 SDL_JoystickGetDeviceInstanceID = _bind("SDL_JoystickGetDeviceInstanceID", [c_int], SDL_JoystickID, added='2.0.6')
 SDL_LockJoysticks = _bind("SDL_LockJoysticks", None, None, added='2.0.7')
 SDL_UnlockJoysticks = _bind("SDL_UnlockJoysticks", None, None, added='2.0.7')
+
+#SDL_JoystickGetGUIDString = _bind("SDL_JoystickGetGUIDString", [SDL_JoystickGUID, c_char_p, c_int])
+def SDL_JoystickGetGUIDString(guid, pszGUID, cbGUID):
+    # Reimplemented in Python due to crash-causing ctypes bug (fixed in 3.8)
+    s = b""
+    for g in guid.data:
+        s += "{:x}".format(g >> 4)
+        s += "{:x}".format(g & 0x0F)
+    pszGUID.value = s[:(cbGUID * 2)]

--- a/sdl2/joystick.py
+++ b/sdl2/joystick.py
@@ -1,3 +1,4 @@
+import sys
 from ctypes import Structure, c_int, c_char_p, c_void_p, POINTER
 from .dll import _bind
 from .stdinc import Sint16, Sint32, Uint16, Uint8, SDL_bool
@@ -109,11 +110,13 @@ SDL_JoystickGetDeviceInstanceID = _bind("SDL_JoystickGetDeviceInstanceID", [c_in
 SDL_LockJoysticks = _bind("SDL_LockJoysticks", None, None, added='2.0.7')
 SDL_UnlockJoysticks = _bind("SDL_UnlockJoysticks", None, None, added='2.0.7')
 
-#SDL_JoystickGetGUIDString = _bind("SDL_JoystickGetGUIDString", [SDL_JoystickGUID, c_char_p, c_int])
-def SDL_JoystickGetGUIDString(guid, pszGUID, cbGUID):
-    # Reimplemented in Python due to crash-causing ctypes bug (fixed in 3.8)
-    s = b""
-    for g in guid.data:
-        s += "{:x}".format(g >> 4)
-        s += "{:x}".format(g & 0x0F)
-    pszGUID.value = s[:(cbGUID * 2)]
+# Reimplemented in Python due to crash-causing ctypes bug (fixed in 3.8)
+if sys.version_info >= (3, 8, 0, 'final'):
+    SDL_JoystickGetGUIDString = _bind("SDL_JoystickGetGUIDString", [SDL_JoystickGUID, c_char_p, c_int])
+else:
+    def SDL_JoystickGetGUIDString(guid, pszGUID, cbGUID):
+        s = b""
+        for g in guid.data:
+            s += "{:x}".format(g >> 4)
+            s += "{:x}".format(g & 0x0F)
+        pszGUID.value = s[:(cbGUID * 2)]

--- a/sdl2/joystick.py
+++ b/sdl2/joystick.py
@@ -115,8 +115,9 @@ if sys.version_info >= (3, 8, 0, 'final'):
     SDL_JoystickGetGUIDString = _bind("SDL_JoystickGetGUIDString", [SDL_JoystickGUID, c_char_p, c_int])
 else:
     def SDL_JoystickGetGUIDString(guid, pszGUID, cbGUID):
-        s = b""
+        s = ""
         for g in guid.data:
-            s += b"{:x}".format(g >> 4)
-            s += b"{:x}".format(g & 0x0F)
+            s += "{:x}".format(g >> 4)
+            s += "{:x}".format(g & 0x0F)
+        s = s.encode('utf-8')
         pszGUID.value = s[:(cbGUID * 2)]

--- a/sdl2/joystick.py
+++ b/sdl2/joystick.py
@@ -117,6 +117,6 @@ else:
     def SDL_JoystickGetGUIDString(guid, pszGUID, cbGUID):
         s = b""
         for g in guid.data:
-            s += "{:x}".format(g >> 4)
-            s += "{:x}".format(g & 0x0F)
+            s += b"{:x}".format(g >> 4)
+            s += b"{:x}".format(g & 0x0F)
         pszGUID.value = s[:(cbGUID * 2)]

--- a/sdl2/test/gamecontroller_test.py
+++ b/sdl2/test/gamecontroller_test.py
@@ -1,28 +1,50 @@
 import sys
 import pytest
-from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_JOYSTICK
-from sdl2 import gamecontroller
+from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_GAMECONTROLLER
+from sdl2 import gamecontroller, joystick
+
+# Make sure gamecontroller subsystem works before running tests
+ret = SDL_Init(SDL_INIT_GAMECONTROLLER)
+SDL_Quit()
+skipmsg = 'Game controller subsystem not supported'
+pytestmark = pytest.mark.skipif(ret != 0, reason=skipmsg)
 
 
 class TestSDLGamecontroller(object):
     __tags__ = ["sdl"]
 
-    @classmethod
-    def setup_class(cls):
-        if SDL_Init(SDL_INIT_JOYSTICK) != 0:
-            raise pytest.skip('Joystick subsystem not supported')
+    def setup_method(self):
+        SDL_Init(SDL_INIT_GAMECONTROLLER)
 
-    @classmethod
-    def teardown_class(cls):
+    def teardown_method(self):
         SDL_Quit()
 
-    @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerAddMapping(self):
-        pass
+        newmap = (
+            b"030000005e0400002700000006010000,Microsoft SideWinder,"
+            b"platform:Mac OS X,a:b0,b:b1,x:b2,y:b3,dpup:-a1,dpdown:+a1,"
+            b"dpleft:-a0,dpright:+a0,lefttrigger:b4,righttrigger:b5"
+        )
+        n1 = gamecontroller.SDL_GameControllerNumMappings()
+        ret = gamecontroller.SDL_GameControllerAddMapping(newmap)
+        assert ret != -1
+        n2 = gamecontroller.SDL_GameControllerNumMappings()
+        assert n2 == n1 + 1
 
-    @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerMappingForGUID(self):
-        pass
+        newmap = (
+            b"030000005e0400002700000006010000,Microsoft SideWinder,"
+            b"platform:Mac OS X,a:b0,b:b1,x:b2,y:b3,dpup:-a1,dpdown:+a1,"
+            b"dpleft:-a0,dpright:+a0,lefttrigger:b4,righttrigger:b5"
+        )
+        ret = gamecontroller.SDL_GameControllerAddMapping(newmap)
+        assert ret != 0
+        # Get GUID for new mapping
+        guid_str = newmap.split(b",")[0]
+        guid = joystick.SDL_JoystickGetGUIDFromString(guid_str)
+        # Get mapping for GUID
+        retmap = gamecontroller.SDL_GameControllerMappingForGUID(guid)
+        assert retmap == newmap
 
     @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerMapping(self):
@@ -60,13 +82,25 @@ class TestSDLGamecontroller(object):
     def test_SDL_GameControllerUpdate(self):
         pass
 
-    @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerGetAxisFromString(self):
-        pass
+        expected = {
+            b'lefty': gamecontroller.SDL_CONTROLLER_AXIS_LEFTY,
+            b'lefttrigger': gamecontroller.SDL_CONTROLLER_AXIS_TRIGGERLEFT,
+            b'notanaxis': gamecontroller.SDL_CONTROLLER_AXIS_INVALID
+        }
+        for string in expected.keys():
+            a = gamecontroller.SDL_GameControllerGetAxisFromString(string)
+            assert a == expected[string]
 
-    @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerGetStringForAxis(self):
-        pass
+        expected = {
+            gamecontroller.SDL_CONTROLLER_AXIS_LEFTY: b'lefty',
+            gamecontroller.SDL_CONTROLLER_AXIS_TRIGGERLEFT: b'lefttrigger',
+            gamecontroller.SDL_CONTROLLER_AXIS_INVALID: None
+        }
+        for axis in expected.keys():
+            s = gamecontroller.SDL_GameControllerGetStringForAxis(axis)
+            assert s == expected[axis]
 
     @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerGetBindForAxis(self):
@@ -76,13 +110,25 @@ class TestSDLGamecontroller(object):
     def test_SDL_GameControllerGetAxis(self):
         pass
 
-    @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerGetButtonFromString(self):
-        pass
+        expected = {
+            b'x': gamecontroller.SDL_CONTROLLER_BUTTON_X,
+            b'dpup': gamecontroller.SDL_CONTROLLER_BUTTON_DPAD_UP,
+            b'notabutton': gamecontroller.SDL_CONTROLLER_BUTTON_INVALID
+        }
+        for string in expected.keys():
+            b = gamecontroller.SDL_GameControllerGetButtonFromString(string)
+            assert b == expected[string]
 
-    @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerGetStringForButton(self):
-        pass
+        expected = {
+            gamecontroller.SDL_CONTROLLER_BUTTON_X: b'x',
+            gamecontroller.SDL_CONTROLLER_BUTTON_DPAD_UP: b'dpup',
+            gamecontroller.SDL_CONTROLLER_BUTTON_INVALID: None
+        }
+        for button in expected.keys():
+            s = gamecontroller.SDL_GameControllerGetStringForButton(button)
+            assert s == expected[button]
 
     @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerGetBindForButton(self):
@@ -120,10 +166,18 @@ class TestSDLGamecontroller(object):
     def test_SDL_GameControllerGetProductVersion(self):
         pass
 
-    @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerNumMappings(self):
-        pass
+        num = gamecontroller.SDL_GameControllerNumMappings()
+        assert num > 0
 
-    @pytest.mark.skip("not implemented")
     def test_SDL_GameControllerMappingForIndex(self):
-        pass
+        newmap = (
+            b"030000005e0400002700000006010000,Microsoft SideWinder,"
+            b"platform:Mac OS X,a:b0,b:b1,x:b2,y:b3,dpup:-a1,dpdown:+a1,"
+            b"dpleft:-a0,dpright:+a0,lefttrigger:b4,righttrigger:b5"
+        )
+        ret = gamecontroller.SDL_GameControllerAddMapping(newmap)
+        assert ret != 0
+        num = gamecontroller.SDL_GameControllerNumMappings()
+        retmap = gamecontroller.SDL_GameControllerMappingForIndex(num - 1)
+        assert newmap == retmap

--- a/sdl2/test/joystick_test.py
+++ b/sdl2/test/joystick_test.py
@@ -1,5 +1,6 @@
 import sys
 import pytest
+from ctypes import create_string_buffer
 from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_JOYSTICK
 from sdl2.events import SDL_QUERY, SDL_ENABLE, SDL_IGNORE
 from sdl2 import joystick
@@ -49,13 +50,18 @@ class TestSDLJoystick(object):
     def test_SDL_JoystickGetGUID(self):
         pass
 
-    @pytest.mark.skip("not implemented")
-    def test_SDL_JoystickGetGUIDString(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
     def test_SDL_JoystickGetGUIDFromString(self):
-        pass
+        guid_str = b'030000007e050000060300001c3a0000' # Wiimote on macOS
+        expected = [3, 0, 0, 0, 126, 5, 0, 0, 6, 3, 0, 0, 28, 58, 0, 0]
+        guid = joystick.SDL_JoystickGetGUIDFromString(guid_str)
+        assert list(guid.data) == expected
+
+    def test_SDL_JoystickGetGUIDString(self):
+        guid_str = b'030000007e050000060300001c3a0000' # Wiimote on macOS
+        guid = joystick.SDL_JoystickGetGUIDFromString(guid_str)
+        buff = create_string_buffer(33)
+        joystick.SDL_JoystickGetGUIDString(guid, buff, 33) # Get GUID string
+        assert guid_str == buff.value
 
     @pytest.mark.skip("not implemented")
     def test_SDL_JoystickGetAttached(self):


### PR DESCRIPTION
Should fix #75. Based on @Kentzo's fix for SDL_JoystickGetGUIDString, but implements the same interface as the actual SDL function, and also fixes SDL_GameControllerMappingForGUID which also caused a segfault for the same reason. The ctypes bug responsible for the segfault is fixed as of Python 3.8.0, so on 3.8+ the real SDL2 functions are used instead of the reimplementations.

Also, in the process I wrote a bunch of new unit tests for the gamepad module, so those are in here too.