### PR TITLE
Add built-in support for the pysdl2-dll package

### DIFF
--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -8,7 +8,7 @@ from ctypes.util import find_library
 # Prints warning without stack or line info
 def prettywarn(msg, warntype):
     original = warnings.showwarning
-    def _warning(message, category = Warning, filename = '', lineno = -1):
+    def _warning(message, category, filename, lineno, file=None, line=None):
         print(message)
     warnings.showwarning = _warning
     warnings.warn(msg, warntype)

--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -5,9 +5,22 @@ import warnings
 from ctypes import CDLL, POINTER, Structure, c_uint8
 from ctypes.util import find_library
 
+# Prints warning without stack or line info
+def prettywarn(msg, warntype):
+    original = warnings.showwarning
+    def _warning(message, category = Warning, filename = '', lineno = -1):
+        print(message)
+    warnings.showwarning = _warning
+    warnings.warn(msg, warntype)
+    warnings.showwarning = original
+
 # Use DLLs from pysdl2-dll, if installed and DLL path not explicitly set
 try:
+    path_in_env = os.getenv('PYSDL2_DLL_PATH')
     import sdl2dll
+    if not path_in_env:
+        msg = "UserWarning: Using SDL2 binaries from pysdl2-dll {0}"
+        prettywarn(msg.format(sdl2dll.__version__), UserWarning)
 except ImportError:
     pass
 
@@ -38,7 +51,7 @@ def _findlib(libnames, path=None):
 
     searchfor = libnames
     results = []
-    if path:
+    if path and path.lower() != "system":
         # First, find any libraries matching pattern exactly within given path
         for libname in searchfor:
             for subpath in str.split(path, os.pathsep):

--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -16,9 +16,10 @@ def prettywarn(msg, warntype):
 
 # Use DLLs from pysdl2-dll, if installed and DLL path not explicitly set
 try:
-    path_in_env = os.getenv('PYSDL2_DLL_PATH')
+    prepath = os.getenv('PYSDL2_DLL_PATH')
     import sdl2dll
-    if not path_in_env:
+    postpath = os.getenv('PYSDL2_DLL_PATH')
+    if prepath != postpath:
         msg = "UserWarning: Using SDL2 binaries from pysdl2-dll {0}"
         prettywarn(msg.format(sdl2dll.__version__), UserWarning)
 except ImportError:

--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -5,6 +5,12 @@ import warnings
 from ctypes import CDLL, POINTER, Structure, c_uint8
 from ctypes.util import find_library
 
+# Use DLLs from pysdl2-dll, if installed and DLL path not explicitly set
+try:
+    import sdl2dll
+except ImportError:
+    pass
+
 __all__ = ["DLL", "nullfunc"]
 
 


### PR DESCRIPTION
Addresses #78, at least for Windows and macOS (Linux support possible, but complicated, with future pysdl2-dll updates).

To summarize my posts in #78: [pysdl2-dll](https://github.com/a-hurst/pysdl2-dll) is a separate package that's essentially just the official SDL2+ttf+mixer+image and unofficial SDL2_gfx binaries for the platform plus an `__init__.py` file that, if `PYSDL2_DLL_PATH` isn't already set, sets it to the path with the DLLs in the package. I've been using this for deploying pysdl2 scripts to virtualenvs on Windows machines for a few months now and it's made installation/usage extremely smooth.

All this pull request does is make pysdl2 try to load pysdl2-dll automatically on launch, so all someone needs to do is run `pip install pysdl2 pysdl2dll` and they'll be able to run any pysdl2 script without any extra setup. Since it's optional, there's also no dependency added in setup.py, so `pip install pysdl2` won't do anything it didn't do before.

Note: pysdl2-dll isn't on PyPI yet, but I have wheels for Win32/Win64/macOS ready to upload once this is approved. In the meantime, it can be installed directly from GitHub using pip.