### PR TITLE
Move full stop out of readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ prebuilt package for your operating system or distribution.
 If you just started with SDL and PySDL2, it is strongly recommended
 that you read through the tutorial of the documentation to learn the
 basics. You can find the documentation at `doc/html` or online at
-<http://pysdl2.readthedocs.org.>
+<http://pysdl2.readthedocs.org>.
 
 ## License
 


### PR DESCRIPTION
The link wan't working as it included the full stop.