### PR TITLE
Set color key for indexed images

### DIFF
--- a/sdl2/ext/image.py
+++ b/sdl2/ext/image.py
@@ -151,4 +151,9 @@ def load_image(fname, enforce=None):
             if ret != 0:
                 raise SDLError()
 
+            # If the image has a single transparent palette index, set
+            # that index as the color key to make blitting correct.
+            if 'transparency' in image.info and isinstance(image.info['transparency'], int):
+                sdl2.SDL_SetColorKey(imgsurface, True, image.info['transparency'])
+
     return imgsurface


### PR DESCRIPTION
Calling load_image using a PNG file with indexed colors discarded the transparent palette index value, so all transparent pixels turned into whatever solid color is internally stored in the file that isn't typically seen. This change takes note of the transparency index and sets this as the color key on the resulting SDL surface, so that blitting operations will treat it as transparent.

The `isinstance` check exists because `info['transparency']` may not be an int: if the file is a PNG file with a per-palette alpha value it will be a bytearray, which is not supported here. See https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html for details on this.

Here's a demo indexed PNG file with palette index zero transparent:

![demo](https://user-images.githubusercontent.com/683985/73596133-7b18ab00-4517-11ea-91e1-43dd9b7bef14.png)

PIL will report that index zero has RGB value (115, 32, 49) which is the color you'll see in place of transparent pixels if you use pysdl2 to blit this onto another surface without this change.
