### PR TITLE
Allowing to detect the SDL2 library on MacOS with its original name.

### DIFF
--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -234,7 +234,7 @@ def nullfunc(*args):
     return
 
 try:
-    dll = DLL("SDL2", ["SDL2", "SDL2-2.0"], os.getenv("PYSDL2_DLL_PATH"))
+    dll = DLL("SDL2", ["SDL2", "SDL2-2.0", "SDL2-2.0.0"], os.getenv("PYSDL2_DLL_PATH"))
 except RuntimeError as exc:
     raise ImportError(exc)
 


### PR DESCRIPTION
The SDL2 library is named libSDL2-2.0.0.dylib by default on MacOS when installed with brew.

Right now, detecting the library on MacOS works because when installing through brew, there is a symlink that is created with the name libSDL2.dylib that links directly to the library itself.

The problem I have is that when building a python wheel on MacOS, I need to include the dependencies to it. The tool that I use (delocate-wheel) copies the library but not the symlink, and pysdl2 is not able to detect the library. 

Since the name SDL2-2.0 was already enabled, I figured it would not be that big a stretch to also add SDL2-2.0.0 as a potential name.