### PR TITLE
Allowing to search for an SDL library that was built in a debug configuration.

### DIFF
--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -50,7 +50,9 @@ def _findlib(libnames, path=None):
     else:
         patterns = ["lib{0}.so"]
 
-    searchfor = libnames
+    # Adding the potential 'd' suffix that is present on the library
+    # when built in debug configuration
+    searchfor = libnames + [libname + 'd' for libname in libnames]
     results = []
     if path and path.lower() != "system":
         # First, find any libraries matching pattern exactly within given path

--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -234,7 +234,7 @@ def nullfunc(*args):
     return
 
 try:
-    dll = DLL("SDL2", ["SDL2", "SDL2-2.0"], os.getenv("PYSDL2_DLL_PATH"))
+    dll = DLL("SDL2", ["SDL2", "SDL2-2.0", "SDL2-2.0.0"], os.getenv("PYSDL2_DLL_PATH"))
 except RuntimeError as exc:
     raise ImportError(exc)
 


### PR DESCRIPTION
The output names of the SDL library, when built with CMake in debug mode, contain a 'd' suffix.
Adding the possibility to detect those libraries with pysdl2.