### PR TITLE
Fix DLL loading with Python from the Microsoft Store 

### DIFF
--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -21,7 +21,7 @@ try:
     import sdl2dll
     postpath = os.getenv('PYSDL2_DLL_PATH')
     if prepath != postpath:
-        msg = "UserWarning: Using SDL2 binaries from pysdl2-dll {0}"
+        msg = "Using SDL2 binaries from pysdl2-dll {0}"
         prettywarn(msg.format(sdl2dll.__version__), UserWarning)
 except ImportError:
     pass
@@ -65,7 +65,7 @@ def _preload_deps(libname, dllpath):
         for dll in all_dlls:
             if dll.startswith(dllname):
                 try:
-                    filepath = os.path.join(dllpath, dll)
+                    filepath = os.path.join(dlldir, dll)
                     preloaded[name] = CDLL(filepath)
                 except OSError:
                     pass


### PR DESCRIPTION
Due to restrictions placed on Microsoft Store apps, Python installed from the Microsoft Store isn't always able to load the SDL2 extension libraries correctly. Specifically, MS Store Python prevents dynamic linking to DLLs that aren't part of the system path or within the app's dependency tree, which prevents the dynamic dependencies for SDL2\_image/mixer/ttf (e.g. libFLAC, libpng) from being loaded, breaking support for multiple sound and image formats.

As a workaround, MS Store Python will allow loading of any libraries already attached to the process, so we can preload the problem DLLs with ctypes when importing image/mixer/ttf to fix things.