### PR TITLE
Skip tests when numpy is not available

### DIFF
--- a/sdl2/test/sdl2ext_draw_test.py
+++ b/sdl2/test/sdl2ext_draw_test.py
@@ -6,6 +6,11 @@ from sdl2.ext.color import Color, COLOR
 from sdl2.ext.compat import ExperimentalWarning
 from sdl2 import ext as sdl2ext
 
+try:
+    import numpy
+    _HASNUMPY = True
+except:
+    _HASNUMPY = False
 
 class TestSDL2ExtDraw(object):
     __tags__ = ["sdl", "sdl2ext"]
@@ -21,6 +26,7 @@ class TestSDL2ExtDraw(object):
     def teardown_class(cls):
         sdl2ext.quit()
 
+    @pytest.mark.skipif(not _HASNUMPY, reason="pixels3d requires numpy module")
     def test_fill(self):
         # Initialize colour and surface/view
         WHITE = (255, 255, 255)
@@ -63,6 +69,7 @@ class TestSDL2ExtDraw(object):
         with pytest.raises(ValueError):
             sdl2ext.fill(sf.contents, WHITE, (1, 2, 3))
 
+    @pytest.mark.skipif(not _HASNUMPY, reason="pixels3d requires numpy module")
     def test_line(self):
         # Initialize colour and surface/view
         WHITE = (255, 255, 255)

--- a/sdl2/test/sdl2ext_font_test.py
+++ b/sdl2/test/sdl2ext_font_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-import numpy as np
 from sdl2 import ext as sdl2ext
 from sdl2.ext.compat import byteify, ExperimentalWarning
 from sdl2.ext.pixelaccess import pixels2d
@@ -46,7 +45,7 @@ class TestSDL2ExtFont(object):
         # Try SDL_Surface surface
         font = sdl2ext.BitmapFont(sf.contents, (32, 32), FONTMAP)
         assert font.size == (32, 32)
-        
+
         # Try SDL_Surface pointer surface
         font = sdl2ext.BitmapFont(sf, (32, 32), FONTMAP)
         assert font.size == (32, 32)
@@ -72,6 +71,7 @@ class TestSDL2ExtFont(object):
             font.render("this_should_fail")
 
     def test_BitmapFont_render_on(self):
+        np = pytest.importorskip("numpy", reason="numpy module is not available")
         # Initialize font, surface, and BitmapFont for tests
         fontpath = byteify(RESOURCES.get_path("font.bmp"), "utf-8")
         sf = surface.SDL_LoadBMP(fontpath)


### PR DESCRIPTION
<!--Thanks for contributing to PySDL2!-->

# PR Description

`sdl2ext_pixelaccess_test` skips tests which require NumPy if NumPy is not installed. Let's do it for the other tests requiring NumPy as well.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
