### PR TITLE
Improved bindings for TTF, Image, Mixer, and GFX

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+image:
+  - Visual Studio 2019
+
 environment:
   SDL_VIDEODRIVER: dummy
   SDL_AUDIODRIVER: dummy

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -2,6 +2,27 @@ Release News
 ============
 This describes the latest changes between the PySDL2 releases.
 
+0.9.10
+------
+
+Released on XXXX-XX-XX.
+
+New Features:
+
+* Updated the :mod:`~sdl2.sdlttf`, :mod:`~sdl2.sdlimage`, :mod:`~sdl2.sdlmixer`,
+  and :mod:`~sdl2.sdlgfx` modules to use a new method of ctypes wrapping that
+  allows functions to support kwargs (i.e. using function arguments by name),
+  inline documentation, and more flexible handling of argument types and
+  SDL errors.
+
+
+Fixed Bugs:
+
+* Fixed a typo in the :mod:`~sdl2.sdlttf` bindings where an alias for the
+  :func:`~sdl2.sdlttf.TTF_RenderUTF8_Shaded` function was incorrectly bound to
+  ``TTF_RenderUTF`` instead of ``TTF_RenderUTF8``.
+
+
 0.9.9
 -----
 

--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -43,6 +43,15 @@ class SDL_version(Structure):
                 ]
 
 
+# Defines an internal container class for SDL function definitions
+class SDLFunc(object):
+    def __init__(self, name, args=None, returns=None, added=None):
+        self.name = name
+        self.args = args
+        self.returns = returns
+        self.added = added
+
+
 def _using_ms_store_python():
     """Checks if the Python interpreter was installed from the Microsoft Store."""
     return 'WindowsApps\\PythonSoftwareFoundation.' in sys.executable

--- a/sdl2/sdlgfx.py
+++ b/sdl2/sdlgfx.py
@@ -1,7 +1,8 @@
 import os
 from ctypes import Structure, POINTER, c_int, c_float, c_void_p, c_char, \
     c_char_p, c_double
-from .dll import DLL
+from ctypes import POINTER as _P
+from .dll import DLL, SDLFunc
 from .stdinc import Uint8, Uint32, Sint16
 from .render import SDL_Renderer
 from .surface import SDL_Surface
@@ -63,10 +64,18 @@ def get_dll_file():
 _bind = dll.bind_function
 
 
+# Constants, enums, type definitions, and macros
+
+SDL2_GFXPRIMITIVES_MAJOR = 1
+SDL2_GFXPRIMITIVES_MINOR = 0
+SDL2_GFXPRIMITIVES_MICRO = 4
+
 FPS_UPPER_LIMIT = 200
 FPS_LOWER_LIMIT = 1
 FPS_DEFAULT = 30
 
+SMOOTHING_OFF = 0
+SMOOTHING_ON = 1
 
 class FPSManager(Structure):
     _fields_ = [("framecount", Uint32),
@@ -76,83 +85,319 @@ class FPSManager(Structure):
                 ("rate", Uint32)
                 ]
 
-SDL_initFramerate = _bind("SDL_initFramerate", [POINTER(FPSManager)])
-SDL_setFramerate = _bind("SDL_setFramerate", [POINTER(FPSManager), Uint32], c_int)
-SDL_getFramerate = _bind("SDL_getFramerate", [POINTER(FPSManager)], c_int)
-SDL_getFramecount = _bind("SDL_getFramecount", [POINTER(FPSManager)], Uint32)
-SDL_framerateDelay = _bind("SDL_framerateDelay", [POINTER(FPSManager)], Uint32)
 
-SDL2_GFXPRIMITIVES_MAJOR = 1
-SDL2_GFXPRIMITIVES_MINOR = 0
-SDL2_GFXPRIMITIVES_MICRO = 4
+# Raw ctypes function definitions
 
-pixelColor = _bind("pixelColor", [POINTER(SDL_Renderer), Sint16, Sint16, Uint32], c_int)
-pixelRGBA = _bind("pixelRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-hlineColor = _bind("hlineColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int)
-hlineRGBA = _bind("hlineRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-vlineColor = _bind("vlineColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int)
-vlineRGBA = _bind("vlineRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-rectangleColor = _bind("rectangleColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-rectangleRGBA = _bind("rectangleRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-roundedRectangleColor = _bind("roundedRectangleColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-roundedRectangleRGBA = _bind("roundedRectangleRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-boxColor = _bind("boxColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-boxRGBA = _bind("boxRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-roundedBoxColor = _bind("roundedBoxColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-roundedBoxRGBA = _bind("roundedBoxRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-lineColor = _bind("lineColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-lineRGBA = _bind("lineRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-aalineColor = _bind("aalineColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-aalineRGBA = _bind("aalineRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-thickLineColor = _bind("thickLineColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint32], c_int)
-thickLineRGBA = _bind("thickLineRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8, Uint8], c_int)
-circleColor = _bind("circleColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int)
-circleRGBA = _bind("circleRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-arcColor = _bind("arcColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-arcRGBA = _bind("arcRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-aacircleColor = _bind("aacircleColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int)
-aacircleRGBA = _bind("aacircleRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-filledCircleColor = _bind("filledCircleColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int)
-filledCircleRGBA = _bind("filledCircleRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-ellipseColor = _bind("ellipseColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-ellipseRGBA = _bind("ellipseRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-aaellipseColor = _bind("aaellipseColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-aaellipseRGBA = _bind("aaellipseRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-filledEllipseColor = _bind("filledEllipseColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-filledEllipseRGBA = _bind("filledEllipseRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-pieColor = _bind("pieColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-pieRGBA = _bind("pieRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-filledPieColor = _bind("filledPieColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-filledPieRGBA = _bind("filledPieRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-trigonColor = _bind("trigonColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-trigonRGBA = _bind("trigonRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-aatrigonColor = _bind("aatrigonColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-aatrigonRGBA = _bind("aatrigonRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-filledTrigonColor = _bind("filledTrigonColor", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int)
-filledTrigonRGBA = _bind("filledTrigonRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int)
-polygonColor = _bind("polygonColor", [POINTER(SDL_Renderer), POINTER(Sint16), POINTER(Sint16), c_int, Uint32], c_int)
-polygonRGBA = _bind("polygonRGBA", [POINTER(SDL_Renderer), POINTER(Sint16), POINTER(Sint16), c_int, Uint8, Uint8, Uint8, Uint8], c_int)
-aapolygonColor = _bind("aapolygonColor", [POINTER(SDL_Renderer), POINTER(Sint16), POINTER(Sint16), c_int, Uint32], c_int)
-aapolygonRGBA = _bind("aapolygonRGBA", [POINTER(SDL_Renderer), POINTER(Sint16), POINTER(Sint16), c_int, Uint8, Uint8, Uint8, Uint8], c_int)
-filledPolygonColor = _bind("filledPolygonColor", [POINTER(SDL_Renderer), POINTER(Sint16), POINTER(Sint16), c_int, Uint32], c_int)
-filledPolygonRGBA = _bind("filledPolygonRGBA", [POINTER(SDL_Renderer), POINTER(Sint16), POINTER(Sint16), c_int, Uint8, Uint8, Uint8, Uint8], c_int)
-texturedPolygon = _bind("texturedPolygon", [POINTER(SDL_Renderer), POINTER(Sint16), POINTER(Sint16), c_int, POINTER(SDL_Surface), c_int, c_int], c_int)
-bezierColor = _bind("bezierColor", [POINTER(SDL_Renderer), POINTER(Sint16), POINTER(Sint16), c_int, c_int, Uint32], c_int)
-bezierRGBA = _bind("bezierRGBA", [POINTER(SDL_Renderer), POINTER(Sint16), POINTER(Sint16), c_int, c_int, Uint8, Uint8, Uint8, Uint8], c_int)
-gfxPrimitivesSetFont = _bind("gfxPrimitivesSetFont", [c_void_p, Uint32, Uint32])
-gfxPrimitivesSetFontRotation = _bind("gfxPrimitivesSetFontRotation", [Uint32])
-characterColor = _bind("characterColor", [POINTER(SDL_Renderer), Sint16, Sint16, c_char, Uint32], c_int)
-characterRGBA = _bind("characterRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, c_char, Uint8, Uint8, Uint8, Uint8], c_int)
-stringColor = _bind("stringColor", [POINTER(SDL_Renderer), Sint16, Sint16, c_char_p, Uint32], c_int)
-stringRGBA = _bind("stringRGBA", [POINTER(SDL_Renderer), Sint16, Sint16, c_char_p, Uint8, Uint8, Uint8, Uint8], c_int)
+_funcdefs = [
+    SDLFunc("SDL_initFramerate", [_P(FPSManager)]),
+    SDLFunc("SDL_setFramerate", [_P(FPSManager), Uint32], c_int),
+    SDLFunc("SDL_getFramerate", [_P(FPSManager)], c_int),
+    SDLFunc("SDL_getFramecount", [_P(FPSManager)], Uint32),
+    SDLFunc("SDL_framerateDelay", [_P(FPSManager)], Uint32),
+    SDLFunc("pixelColor", [_P(SDL_Renderer), Sint16, Sint16, Uint32], c_int),
+    SDLFunc("pixelRGBA", [_P(SDL_Renderer), Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("hlineColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("hlineRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("vlineColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("vlineRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("rectangleColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("rectangleRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("roundedRectangleColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("roundedRectangleRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("boxColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("boxRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("roundedBoxColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("roundedBoxRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("lineColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("lineRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("aalineColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("aalineRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("thickLineColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint32], c_int),
+    SDLFunc("thickLineRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("circleColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("circleRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("arcColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("arcRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("aacircleColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("aacircleRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("filledCircleColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("filledCircleRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("ellipseColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("ellipseRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("aaellipseColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("aaellipseRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("filledEllipseColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("filledEllipseRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("pieColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("pieRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("filledPieColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("filledPieRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("trigonColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("trigonRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("aatrigonColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("aatrigonRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("filledTrigonColor", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint32], c_int),
+    SDLFunc("filledTrigonRGBA", [_P(SDL_Renderer), Sint16, Sint16, Sint16, Sint16, Sint16, Sint16, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("polygonColor", [_P(SDL_Renderer), _P(Sint16), _P(Sint16), c_int, Uint32], c_int),
+    SDLFunc("polygonRGBA", [_P(SDL_Renderer), _P(Sint16), _P(Sint16), c_int, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("aapolygonColor", [_P(SDL_Renderer), _P(Sint16), _P(Sint16), c_int, Uint32], c_int),
+    SDLFunc("aapolygonRGBA", [_P(SDL_Renderer), _P(Sint16), _P(Sint16), c_int, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("filledPolygonColor", [_P(SDL_Renderer), _P(Sint16), _P(Sint16), c_int, Uint32], c_int),
+    SDLFunc("filledPolygonRGBA", [_P(SDL_Renderer), _P(Sint16), _P(Sint16), c_int, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("texturedPolygon", [_P(SDL_Renderer), _P(Sint16), _P(Sint16), c_int, _P(SDL_Surface), c_int, c_int], c_int),
+    SDLFunc("bezierColor", [_P(SDL_Renderer), _P(Sint16), _P(Sint16), c_int, c_int, Uint32], c_int),
+    SDLFunc("bezierRGBA", [_P(SDL_Renderer), _P(Sint16), _P(Sint16), c_int, c_int, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("gfxPrimitivesSetFont", [c_void_p, Uint32, Uint32]),
+    SDLFunc("gfxPrimitivesSetFontRotation", [Uint32]),
+    SDLFunc("characterColor", [_P(SDL_Renderer), Sint16, Sint16, c_char, Uint32], c_int),
+    SDLFunc("characterRGBA", [_P(SDL_Renderer), Sint16, Sint16, c_char, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("stringColor", [_P(SDL_Renderer), Sint16, Sint16, c_char_p, Uint32], c_int),
+    SDLFunc("stringRGBA", [_P(SDL_Renderer), Sint16, Sint16, c_char_p, Uint8, Uint8, Uint8, Uint8], c_int),
+    SDLFunc("rotozoomSurface", [_P(SDL_Surface), c_double, c_double, c_int], _P(SDL_Surface)),
+    SDLFunc("rotozoomSurfaceXY", [_P(SDL_Surface), c_double, c_double, c_double, c_int], _P(SDL_Surface)),
+    SDLFunc("rotozoomSurfaceSize", [c_int, c_int, c_double, c_double, _P(c_int), _P(c_int)]),
+    SDLFunc("rotozoomSurfaceSizeXY", [c_int, c_int, c_double, c_double, c_double, _P(c_int), _P(c_int)]),
+    SDLFunc("zoomSurface", [_P(SDL_Surface), c_double, c_double, c_int], _P(SDL_Surface)),
+    SDLFunc("zoomSurfaceSize", [c_int, c_int, c_double, c_double, _P(c_int), _P(c_int)]),
+    SDLFunc("shrinkSurface", [_P(SDL_Surface), c_int, c_int], _P(SDL_Surface)),
+    SDLFunc("rotateSurface90Degrees", [_P(SDL_Surface), c_int], _P(SDL_Surface)),
+]
+_funcs = {}
+for f in _funcdefs:
+    _funcs[f.name] = _bind(f.name, f.args, f.returns, f.added)
 
-SMOOTHING_OFF = 0
-SMOOTHING_ON = 1
-rotozoomSurface = _bind("rotozoomSurface", [POINTER(SDL_Surface), c_double, c_double, c_int], POINTER(SDL_Surface))
-rotozoomSurfaceXY = _bind("rotozoomSurfaceXY", [POINTER(SDL_Surface), c_double, c_double, c_double, c_int], POINTER(SDL_Surface))
-rotozoomSurfaceSize = _bind("rotozoomSurfaceSize", [c_int, c_int, c_double, c_double, POINTER(c_int), POINTER(c_int)])
-rotozoomSurfaceSizeXY = _bind("rotozoomSurfaceSizeXY", [c_int, c_int, c_double, c_double, c_double, POINTER(c_int), POINTER(c_int)])
-zoomSurface = _bind("zoomSurface", [POINTER(SDL_Surface), c_double, c_double, c_int], POINTER(SDL_Surface))
-zoomSurfaceSize = _bind("zoomSurfaceSize", [c_int, c_int, c_double, c_double, POINTER(c_int), POINTER(c_int)])
-shrinkSurface = _bind("shrinkSurface", [POINTER(SDL_Surface), c_int, c_int], POINTER(SDL_Surface))
-rotateSurface90Degrees = _bind("rotateSurface90Degrees", [POINTER(SDL_Surface), c_int], POINTER(SDL_Surface))
+
+# Python wrapper functions
+
+def SDL_initFramerate(manager):
+    return _funcs["SDL_initFramerate"](manager)
+
+def SDL_setFramerate(manager, rate):
+    return _funcs["SDL_setFramerate"](manager, rate)
+
+def SDL_getFramerate(manager):
+    return _funcs["SDL_getFramerate"](manager)
+
+def SDL_getFramecount(manager):
+    return _funcs["SDL_getFramecount"](manager)
+
+def SDL_framerateDelay(manager):
+    return _funcs["SDL_framerateDelay"](manager)
+
+
+def pixelColor(renderer, x, y, color):
+    return _funcs["pixelColor"](renderer, x, y, color)
+
+def pixelRGBA(renderer, x, y, r, g, b, a):
+    return _funcs["pixelRGBA"](renderer, x, y, r, g, b, a)
+
+def hlineColor(renderer, x1, x2, y, color):
+    return _funcs["hlineColor"](renderer, x1, x2, y, color)
+
+def hlineRGBA(renderer, x1, x2, y, r, g, b, a):
+    return _funcs["hlineRGBA"](renderer, x1, x2, y, r, g, b, a)
+
+def vlineColor(renderer, x, y1, y2, color):
+    return _funcs["vlineColor"](renderer, x, y1, y2, color)
+
+def vlineRGBA(renderer, x, y1, y2, r, g, b, a):
+    return _funcs["vlineRGBA"](renderer, x, y1, y2, r, g, b, a)
+
+
+def rectangleColor(renderer, x1, y1, x2, y2, color):
+    return _funcs["rectangleColor"](renderer, x1, y1, x2, y2, color)
+
+def rectangleRGBA(renderer, x1, y1, x2, y2, r, g, b, a):
+    return _funcs["rectangleRGBA"](renderer, x1, y1, x2, y2, r, g, b, a)
+
+def roundedRectangleColor(renderer, x1, y1, x2, y2, rad, color):
+    return _funcs["roundedRectangleColor"](renderer, x1, y1, x2, y2, rad, color)
+
+def roundedRectangleRGBA(renderer, x1, y1, x2, y2, rad, r, g, b, a):
+    return _funcs["roundedRectangleRGBA"](renderer, x1, y1, x2, y2, rad, r, g, b, a)
+
+def boxColor(renderer, x1, y1, x2, y2, color):
+    return _funcs["boxColor"](renderer, x1, y1, x2, y2, color)
+
+def boxRGBA(renderer, x1, y1, x2, y2, r, g, b, a):
+    return _funcs["boxRGBA"](renderer, x1, y1, x2, y2, r, g, b, a)
+
+def roundedBoxColor(renderer, x1, y1, x2, y2, rad, color):
+    return _funcs["roundedBoxColor"](renderer, x1, y1, x2, y2, rad, color)
+
+def roundedBoxRGBA(renderer, x1, y1, x2, y2, rad, r, g, b, a):
+    return _funcs["roundedBoxRGBA"](renderer, x1, y1, x2, y2, rad, r, g, b, a)
+
+
+def lineColor(renderer, x1, y1, x2, y2, color):
+    return _funcs["lineColor"](renderer, x1, y1, x2, y2, color)
+
+def lineRGBA(renderer, x1, y1, x2, y2, r, g, b, a):
+    return _funcs["lineRGBA"](renderer, x1, y1, x2, y2, r, g, b, a)
+
+def aalineColor(renderer, x1, y1, x2, y2, color):
+    return _funcs["aalineColor"](renderer, x1, y1, x2, y2, color)
+
+def aalineRGBA(renderer, x1, y1, x2, y2, r, g, b, a):
+    return _funcs["aalineRGBA"](renderer, x1, y1, x2, y2, r, g, b, a)
+
+def thickLineColor(renderer, x1, y1, x2, y2, width, color):
+    return _funcs["thickLineColor"](renderer, x1, y1, x2, y2, width, color)
+
+def thickLineRGBA(renderer, x1, y1, x2, y2, width, r, g, b, a):
+    return _funcs["thickLineRGBA"](renderer, x1, y1, x2, y2, width, r, g, b, a)
+
+
+def circleColor(renderer, x, y, rad, color):
+    return _funcs["circleColor"](renderer, x, y, rad, color)
+
+def circleRGBA(renderer, x, y, rad, r, g, b, a):
+    return _funcs["circleRGBA"](renderer, x, y, rad, r, g, b, a)
+
+def arcColor(renderer, x, y, rad, start, end, color):
+    return _funcs["arcColor"](renderer, x, y, rad, start, end, color)
+
+def arcRGBA(renderer, x, y, rad, start, end, r, g, b, a):
+    return _funcs["arcRGBA"](renderer, x, y, rad, start, end, r, g, b, a)
+
+def aacircleColor(renderer, x, y, rad, color):
+    return _funcs["aacircleColor"](renderer, x, y, rad, color)
+
+def aacircleRGBA(renderer, x, y, rad, r, g, b, a):
+    return _funcs["aacircleRGBA"](renderer, x, y, rad, r, g, b, a)
+
+def filledCircleColor(renderer, x, y, rad, color):
+    return _funcs["filledCircleColor"](renderer, x, y, rad, color)
+
+def filledCircleRGBA(renderer, x, y, rad, r, g, b, a):
+    return _funcs["filledCircleRGBA"](renderer, x, y, rad, r, g, b, a)
+
+
+def ellipseColor(renderer, x, y, rx, ry, color):
+    return _funcs["ellipseColor"](renderer, x, y, rx, ry, color)
+
+def ellipseRGBA(renderer, x, y, rx, ry, r, g, b, a):
+    return _funcs["ellipseRGBA"](renderer, x, y, rx, ry, r, g, b, a)
+
+def aaellipseColor(renderer, x, y, rx, ry, color):
+    return _funcs["aaellipseColor"](renderer, x, y, rx, ry, color)
+
+def aaellipseRGBA(renderer, x, y, rx, ry, r, g, b, a):
+    return _funcs["aaellipseRGBA"](renderer, x, y, rx, ry, r, g, b, a)
+
+def filledEllipseColor(renderer, x, y, rx, ry, color):
+    return _funcs["filledEllipseColor"](renderer, x, y, rx, ry, color)
+
+def filledEllipseRGBA(renderer, x, y, rx, ry, r, g, b, a):
+    return _funcs["filledEllipseRGBA"](renderer, x, y, rx, ry, r, g, b, a)
+
+
+def pieColor(renderer, x, y, rad, start, end, color):
+    return _funcs["pieColor"](renderer, x, y, rad, start, end, color)
+
+def pieRGBA(renderer, x, y, rad, start, end, r, g, b, a):
+    return _funcs["pieRGBA"](renderer, x, y, rad, start, end, r, g, b, a)
+
+def filledPieColor(renderer, x, y, rad, start, end, color):
+    return _funcs["filledPieColor"](renderer, x, y, rad, start, end, color)
+
+def filledPieRGBA(renderer, x, y, rad, start, end, r, g, b, a):
+    return _funcs["filledPieRGBA"](renderer, x, y, rad, start, end, r, g, b, a)
+
+
+def trigonColor(renderer, x1, y1, x2, y2, x3, y3, color):
+    return _funcs["trigonColor"](renderer, x1, y1, x2, y2, x3, y3, color)
+
+def trigonRGBA(renderer, x1, y1, x2, y2, x3, y3, r, g, b, a):
+    return _funcs["trigonRGBA"](renderer, x1, y1, x2, y2, x3, y3, r, g, b, a)
+
+def aatrigonColor(renderer, x1, y1, x2, y2, x3, y3, color):
+    return _funcs["aatrigonColor"](renderer, x1, y1, x2, y2, x3, y3, color)
+
+def aatrigonRGBA(renderer, x1, y1, x2, y2, x3, y3, r, g, b, a):
+    return _funcs["aatrigonRGBA"](renderer, x1, y1, x2, y2, x3, y3, r, g, b, a)
+
+def filledTrigonColor(renderer, x1, y1, x2, y2, x3, y3, color):
+    return _funcs["filledTrigonColor"](renderer, x1, y1, x2, y2, x3, y3, color)
+
+def filledTrigonRGBA(renderer, x1, y1, x2, y2, x3, y3, r, g, b, a):
+    return _funcs["filledTrigonRGBA"](renderer, x1, y1, x2, y2, x3, y3, r, g, b, a)
+
+
+def polygonColor(renderer, vx, vy, n, color):
+    return _funcs["polygonColor"](renderer, vx, vy, n, color)
+
+def polygonRGBA(renderer, vx, vy, n, r, g, b, a):
+    return _funcs["polygonRGBA"](renderer, vx, vy, n, r, g, b, a)
+
+def aapolygonColor(renderer, vx, vy, n, color):
+    return _funcs["aapolygonColor"](renderer, vx, vy, n, color)
+
+def aapolygonRGBA(renderer, vx, vy, n, r, g, b, a):
+    return _funcs["aapolygonRGBA"](renderer, vx, vy, n, r, g, b, a)
+
+def filledPolygonColor(renderer, vx, vy, n, color):
+    return _funcs["filledPolygonColor"](renderer, vx, vy, n, color)
+
+def filledPolygonRGBA(renderer, vx, vy, n, r, g, b, a):
+    return _funcs["filledPolygonRGBA"](renderer, vx, vy, n, r, g, b, a)
+
+def texturedPolygon(renderer, vx, vy, n, texture, texture_dx, texture_dy):
+    return _funcs["texturedPolygon"](
+        renderer, vx, vy, n, texture, texture_dx, texture_dy
+    )
+
+
+def bezierColor(renderer, vx, vy, n, s, color):
+    return _funcs["bezierColor"](renderer, vx, vy, n, s, color)
+
+def bezierRGBA(renderer, vx, vy, n, s, r, g, b, a):
+    return _funcs["bezierRGBA"](renderer, vx, vy, n, s, r, g, b, a)
+
+
+def gfxPrimitivesSetFont(fontdata, cw, ch):
+    return _funcs["gfxPrimitivesSetFont"](fontdata, cw, ch)
+
+def gfxPrimitivesSetFontRotation(rotation):
+    return _funcs["gfxPrimitivesSetFontRotation"](rotation)
+
+def characterColor(renderer, x, y, c, color):
+    return _funcs["characterColor"](renderer, x, y, c, color)
+
+def characterRGBA(renderer, x, y, c, r, g, b, a):
+    return _funcs["characterRGBA"](renderer, x, y, c, r, g, b, a)
+
+def stringColor(renderer, x, y, s, color):
+    return _funcs["stringColor"](renderer, x, y, s, color)
+
+def stringRGBA(renderer, x, y, s, r, g, b, a):
+    return _funcs["stringRGBA"](renderer, x, y, s, r, g, b, a)
+
+
+def rotozoomSurface(src, angle, zoom, smooth):
+    return _funcs["rotozoomSurface"](src, angle, zoom, smooth)
+
+def rotozoomSurfaceXY(src, angle, zoomx, zoomy, smooth):
+    return _funcs["rotozoomSurfaceXY"](src, angle, zoomx, zoomy, smooth)
+
+def rotozoomSurfaceSize(width, height, angle, zoom, dstwidth, dstheight):
+    return _funcs["rotozoomSurfaceSize"](
+        width, height, angle, zoom, dstwidth, dstheight
+    )
+
+def rotozoomSurfaceSizeXY(width, height, angle, zoomx, zoomy, dstwidth, dstheight):
+    return _funcs["rotozoomSurfaceSizeXY"](
+        width, height, angle, zoomx, zoomy, dstwidth, dstheight
+    )
+
+def zoomSurface(src, zoomx, zoomy, smooth):
+    return _funcs["zoomSurface"](src, zoomx, zoomy, smooth)
+
+def zoomSurfaceSize(width, height, zoomx, zoomy, dstwidth, dstheight):
+    return _funcs["zoomSurfaceSize"](width, height, zoomx, zoomy, dstwidth, dstheight)
+
+def shrinkSurface(src, factorx, factory):
+    return _funcs["shrinkSurface"](src, factorx, factory)
+
+def rotateSurface90Degrees(src, numClockwiseTurns):
+    return _funcs["rotateSurface90Degrees"](src, numClockwiseTurns)

--- a/sdl2/sdlimage.py
+++ b/sdl2/sdlimage.py
@@ -1,6 +1,7 @@
 import os
 from ctypes import POINTER, c_int, c_char_p
-from .dll import DLL
+from ctypes import POINTER as _P
+from .dll import DLL, SDLFunc
 from .version import SDL_version, SDL_VERSIONNUM
 from .surface import SDL_Surface
 from .rwops import SDL_RWops
@@ -51,10 +52,12 @@ def get_dll_file():
 
 _bind = dll.bind_function
 
+
+# Constants, enums, type definitions, and macros
+
 SDL_IMAGE_MAJOR_VERSION = 2
 SDL_IMAGE_MINOR_VERSION = 0
 SDL_IMAGE_PATCHLEVEL = 5
-
 
 def SDL_IMAGE_VERSION(x):
     x.major = SDL_IMAGE_MAJOR_VERSION
@@ -64,62 +67,208 @@ def SDL_IMAGE_VERSION(x):
 SDL_IMAGE_COMPILEDVERSION = SDL_VERSIONNUM(SDL_IMAGE_MAJOR_VERSION, SDL_IMAGE_MINOR_VERSION, SDL_IMAGE_PATCHLEVEL)
 SDL_IMAGE_VERSION_ATLEAST = lambda x, y, z: (SDL_IMAGE_COMPILEDVERSION >= SDL_VERSIONNUM(x, y, z))
 
-IMG_Linked_Version = _bind("IMG_Linked_Version", None, POINTER(SDL_version))
-
 IMG_InitFlags = c_int
 IMG_INIT_JPG = 0x00000001
 IMG_INIT_PNG = 0x00000002
 IMG_INIT_TIF = 0x00000004
 IMG_INIT_WEBP = 0x00000008
 
-IMG_Init = _bind("IMG_Init", [c_int], c_int)
-IMG_Quit = _bind("IMG_Quit")
-IMG_LoadTyped_RW = _bind("IMG_LoadTyped_RW", [POINTER(SDL_RWops), c_int, c_char_p], POINTER(SDL_Surface))
-IMG_Load = _bind("IMG_Load", [c_char_p], POINTER(SDL_Surface))
-IMG_Load_RW = _bind("IMG_Load_RW", [POINTER(SDL_RWops), c_int], POINTER(SDL_Surface))
-IMG_LoadTexture = _bind("IMG_LoadTexture", [POINTER(SDL_Renderer), c_char_p], POINTER(SDL_Texture))
-IMG_LoadTexture_RW = _bind("IMG_LoadTexture_RW", [POINTER(SDL_Renderer), POINTER(SDL_RWops), c_int], POINTER(SDL_Texture))
-IMG_LoadTextureTyped_RW = _bind("IMG_LoadTextureTyped_RW", [POINTER(SDL_Renderer), POINTER(SDL_RWops), c_int, c_char_p], POINTER(SDL_Texture))
 
-IMG_isICO = _bind("IMG_isICO", [POINTER(SDL_RWops)], c_int)
-IMG_isCUR = _bind("IMG_isCUR", [POINTER(SDL_RWops)], c_int)
-IMG_isBMP = _bind("IMG_isBMP", [POINTER(SDL_RWops)], c_int)
-IMG_isGIF = _bind("IMG_isGIF", [POINTER(SDL_RWops)], c_int)
-IMG_isJPG = _bind("IMG_isJPG", [POINTER(SDL_RWops)], c_int)
-IMG_isLBM = _bind("IMG_isLBM", [POINTER(SDL_RWops)], c_int)
-IMG_isPCX = _bind("IMG_isPCX", [POINTER(SDL_RWops)], c_int)
-IMG_isPNG = _bind("IMG_isPNG", [POINTER(SDL_RWops)], c_int)
-IMG_isPNM = _bind("IMG_isPNM", [POINTER(SDL_RWops)], c_int)
-IMG_isSVG = _bind("IMG_isSVG", [POINTER(SDL_RWops)], c_int, added='2.0.2')
-IMG_isTIF = _bind("IMG_isTIF", [POINTER(SDL_RWops)], c_int)
-IMG_isXCF = _bind("IMG_isXCF", [POINTER(SDL_RWops)], c_int)
-IMG_isXPM = _bind("IMG_isXPM", [POINTER(SDL_RWops)], c_int)
-IMG_isXV = _bind("IMG_isXV", [POINTER(SDL_RWops)], c_int)
-IMG_isWEBP = _bind("IMG_isWEBP", [POINTER(SDL_RWops)], c_int)
+# Raw ctypes function definitions
 
-IMG_LoadICO_RW = _bind("IMG_LoadICO_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadCUR_RW = _bind("IMG_LoadCUR_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadBMP_RW = _bind("IMG_LoadBMP_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadGIF_RW = _bind("IMG_LoadGIF_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadJPG_RW = _bind("IMG_LoadJPG_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadLBM_RW = _bind("IMG_LoadLBM_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadPCX_RW = _bind("IMG_LoadPCX_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadPNG_RW = _bind("IMG_LoadPNG_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadPNM_RW = _bind("IMG_LoadPNM_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadSVG_RW = _bind("IMG_LoadSVG_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface), added='2.0.2')
-IMG_LoadTGA_RW = _bind("IMG_LoadTGA_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadTIF_RW = _bind("IMG_LoadTIF_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadXCF_RW = _bind("IMG_LoadXCF_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadXPM_RW = _bind("IMG_LoadXPM_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadXV_RW = _bind("IMG_LoadXV_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
-IMG_LoadWEBP_RW = _bind("IMG_LoadWEBP_RW", [POINTER(SDL_RWops)], POINTER(SDL_Surface))
+_funcdefs = [
+    SDLFunc("IMG_Linked_Version", None, _P(SDL_version)),
+    SDLFunc("IMG_Init", [c_int], c_int),
+    SDLFunc("IMG_Quit"),
+    SDLFunc("IMG_LoadTyped_RW", [_P(SDL_RWops), c_int, c_char_p], _P(SDL_Surface)),
+    SDLFunc("IMG_Load", [c_char_p], _P(SDL_Surface)),
+    SDLFunc("IMG_Load_RW", [_P(SDL_RWops), c_int], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadTexture", [_P(SDL_Renderer), c_char_p], _P(SDL_Texture)),
+    SDLFunc("IMG_LoadTexture_RW", [_P(SDL_Renderer), _P(SDL_RWops), c_int], _P(SDL_Texture)),
+    SDLFunc("IMG_LoadTextureTyped_RW", [_P(SDL_Renderer), _P(SDL_RWops), c_int, c_char_p], _P(SDL_Texture)),
+    SDLFunc("IMG_isICO", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isCUR", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isBMP", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isGIF", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isJPG", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isLBM", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isPCX", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isPNG", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isPNM", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isSVG", [_P(SDL_RWops)], c_int, added='2.0.2'),
+    SDLFunc("IMG_isTIF", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isXCF", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isXPM", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isXV", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_isWEBP", [_P(SDL_RWops)], c_int),
+    SDLFunc("IMG_LoadICO_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadCUR_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadBMP_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadGIF_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadJPG_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadLBM_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadPCX_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadPNG_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadPNM_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadSVG_RW", [_P(SDL_RWops)], _P(SDL_Surface), added='2.0.2'),
+    SDLFunc("IMG_LoadTGA_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadTIF_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadXCF_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadXPM_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadXV_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_LoadWEBP_RW", [_P(SDL_RWops)], _P(SDL_Surface)),
+    SDLFunc("IMG_ReadXPMFromArray", [_P(c_char_p)], _P(SDL_Surface)),
+    SDLFunc("IMG_SaveJPG", [_P(SDL_Surface), c_char_p, c_int], c_int, added='2.0.2'),
+    SDLFunc("IMG_SaveJPG_RW", [_P(SDL_Surface), _P(SDL_RWops), c_int, c_int], c_int, added='2.0.2'),
+    SDLFunc("IMG_SavePNG", [_P(SDL_Surface), c_char_p], c_int),
+    SDLFunc("IMG_SavePNG_RW", [_P(SDL_Surface), _P(SDL_RWops), c_int], c_int),
+]
+_funcs = {}
+for f in _funcdefs:
+    _funcs[f.name] = _bind(f.name, f.args, f.returns, f.added)
 
-IMG_ReadXPMFromArray = _bind("IMG_ReadXPMFromArray", [POINTER(c_char_p)], POINTER(SDL_Surface))
 
-IMG_SaveJPG = _bind("IMG_SaveJPG", [POINTER(SDL_Surface), c_char_p, c_int], c_int, added='2.0.2')
-IMG_SaveJPG_RW = _bind("IMG_SaveJPG_RW", [POINTER(SDL_Surface), POINTER(SDL_RWops), c_int, c_int], c_int, added='2.0.2')
-IMG_SavePNG = _bind("IMG_SavePNG", [POINTER(SDL_Surface), c_char_p], c_int)
-IMG_SavePNG_RW = _bind("IMG_SavePNG_RW", [POINTER(SDL_Surface), POINTER(SDL_RWops), c_int], c_int)
+# Python wrapper functions
+
+def IMG_Linked_Version():
+    return _funcs["IMG_Linked_Version"]()
+
+def IMG_Init(flags):
+    return _funcs["IMG_Init"](flags)
+
+def IMG_Quit():
+    return _funcs["IMG_Quit"]()
+
+def IMG_LoadTyped_RW(src, freesrc, type):
+    return _funcs["IMG_LoadTyped_RW"](src, freesrc, type)
+
+def IMG_Load(file):
+    return _funcs["IMG_Load"](file)
+
+def IMG_Load_RW(src, freesrc):
+    return _funcs["IMG_Load_RW"](src, freesrc)
+
+def IMG_LoadTexture(renderer, file):
+    return _funcs["IMG_LoadTexture"](renderer, file)
+
+def IMG_LoadTexture_RW(renderer, src, freesrc):
+    return _funcs["IMG_LoadTexture_RW"](renderer, src, freesrc)
+
+def IMG_LoadTextureTyped_RW(renderer, src, freesrc, type):
+    return _funcs["IMG_LoadTextureTyped_RW"](renderer, src, freesrc, type)
+
+
+def IMG_isICO(src):
+    return _funcs["IMG_isICO"](src)
+
+def IMG_isCUR(src):
+    return _funcs["IMG_isCUR"](src)
+
+def IMG_isBMP(src):
+    return _funcs["IMG_isBMP"](src)
+
+def IMG_isGIF(src):
+    return _funcs["IMG_isGIF"](src)
+
+def IMG_isJPG(src):
+    return _funcs["IMG_isJPG"](src)
+
+def IMG_isLBM(src):
+    return _funcs["IMG_isLBM"](src)
+
+def IMG_isPCX(src):
+    return _funcs["IMG_isPCX"](src)
+
+def IMG_isPNG(src):
+    return _funcs["IMG_isPNG"](src)
+
+def IMG_isPNM(src):
+    return _funcs["IMG_isPNM"](src)
+
+def IMG_isSVG(src):
+    return _funcs["IMG_isSVG"](src)
+
+def IMG_isTIF(src):
+    return _funcs["IMG_isTIF"](src)
+
+def IMG_isXCF(src):
+    return _funcs["IMG_isXCF"](src)
+
+def IMG_isXPM(src):
+    return _funcs["IMG_isXPM"](src)
+
+def IMG_isXV(src):
+    return _funcs["IMG_isXV"](src)
+
+def IMG_isWEBP(src):
+    return _funcs["IMG_isWEBP"](src)
+
+
+def IMG_LoadICO_RW(src):
+    return _funcs["IMG_LoadICO_RW"](src)
+
+def IMG_LoadCUR_RW(src):
+    return _funcs["IMG_LoadCUR_RW"](src)
+
+def IMG_LoadBMP_RW(src):
+    return _funcs["IMG_LoadBMP_RW"](src)
+
+def IMG_LoadGIF_RW(src):
+    return _funcs["IMG_LoadGIF_RW"](src)
+
+def IMG_LoadJPG_RW(src):
+    return _funcs["IMG_LoadJPG_RW"](src)
+
+def IMG_LoadLBM_RW(src):
+    return _funcs["IMG_LoadLBM_RW"](src)
+
+def IMG_LoadPCX_RW(src):
+    return _funcs["IMG_LoadPCX_RW"](src)
+
+def IMG_LoadPNG_RW(src):
+    return _funcs["IMG_LoadPNG_RW"](src)
+
+def IMG_LoadPNM_RW(src):
+    return _funcs["IMG_LoadPNM_RW"](src)
+
+def IMG_LoadSVG_RW(src):
+    return _funcs["IMG_LoadSVG_RW"](src)
+
+def IMG_LoadTGA_RW(src):
+    return _funcs["IMG_LoadTGA_RW"](src)
+
+def IMG_LoadTIF_RW(src):
+    return _funcs["IMG_LoadTIF_RW"](src)
+
+def IMG_LoadXCF_RW(src):
+    return _funcs["IMG_LoadXCF_RW"](src)
+
+def IMG_LoadXPM_RW(src):
+    return _funcs["IMG_LoadXPM_RW"](src)
+
+def IMG_LoadXV_RW(src):
+    return _funcs["IMG_LoadXV_RW"](src)
+
+def IMG_LoadWEBP_RW(src):
+    return _funcs["IMG_LoadWEBP_RW"](src)
+
+
+def IMG_ReadXPMFromArray(xpm):
+    return _funcs["IMG_ReadXPMFromArray"](xpm)
+
+
+def IMG_SavePNG(surface, file):
+    return _funcs["IMG_SavePNG"](surface, file)
+
+def IMG_SavePNG_RW(surface, dst, freedst):
+    return _funcs["IMG_SavePNG_RW"](surface, dst, freedst)
+
+def IMG_SaveJPG(surface, file, quality):
+    return _funcs["IMG_SaveJPG"](surface, file, quality)
+
+def IMG_SaveJPG_RW(surface, dst, freedst, quality):
+    return _funcs["IMG_SaveJPG_RW"](surface, dst, freedst, quality)
+
 
 IMG_SetError = SDL_SetError
 IMG_GetError = SDL_GetError

--- a/sdl2/sdlimage.py
+++ b/sdl2/sdlimage.py
@@ -264,9 +264,11 @@ def IMG_SavePNG_RW(surface, dst, freedst):
     return _funcs["IMG_SavePNG_RW"](surface, dst, freedst)
 
 def IMG_SaveJPG(surface, file, quality):
+    # NOTE: Not available in official macOS binaries
     return _funcs["IMG_SaveJPG"](surface, file, quality)
 
 def IMG_SaveJPG_RW(surface, dst, freedst, quality):
+    # NOTE: Not available in official macOS binaries
     return _funcs["IMG_SaveJPG_RW"](surface, dst, freedst, quality)
 
 

--- a/sdl2/sdlmixer.py
+++ b/sdl2/sdlmixer.py
@@ -154,6 +154,9 @@ class Mix_Chunk(Structure):
 class Mix_Music(c_void_p):
     pass
 
+
+# Callback function definitions for various methods 
+
 mix_func = CFUNCTYPE(None, c_void_p, _P(Uint8), c_int)
 music_finished = CFUNCTYPE(None)
 channel_finished = CFUNCTYPE(None, c_int)

--- a/sdl2/sdlmixer.py
+++ b/sdl2/sdlmixer.py
@@ -365,8 +365,8 @@ def Mix_ReserveChannels(num):
 def Mix_GroupChannel(which, tag):
     return _funcs["Mix_GroupChannel"](which, tag)
 
-def Mix_GroupChannels(from, to, tag):
-    return _funcs["Mix_GroupChannels"](from, to, tag)
+def Mix_GroupChannels(from_, to, tag):
+    return _funcs["Mix_GroupChannels"](from_, to, tag)
 
 def Mix_GroupAvailable(tag):
     return _funcs["Mix_GroupAvailable"](tag)

--- a/sdl2/sdlmixer.py
+++ b/sdl2/sdlmixer.py
@@ -1,7 +1,7 @@
 import os
-from ctypes import Structure, POINTER, CFUNCTYPE, c_int, c_char_p, c_void_p, \
-    c_double
-from .dll import DLL
+from ctypes import Structure, CFUNCTYPE, c_int, c_char_p, c_void_p, c_double
+from ctypes import POINTER as _P
+from .dll import DLL, SDLFunc
 from .version import SDL_version, SDL_VERSIONNUM
 from .audio import AUDIO_S16LSB, AUDIO_S16MSB, SDL_MIX_MAXVOLUME
 from .stdinc import Uint8, Uint16, Uint32, Sint16, SDL_bool
@@ -88,10 +88,12 @@ def get_dll_file():
 
 _bind = dll.bind_function
 
+
+# Constants, enums, type definitions, and macros
+
 SDL_MIXER_MAJOR_VERSION = 2
 SDL_MIXER_MINOR_VERSION = 0
 SDL_MIXER_PATCHLEVEL = 4
-
 
 def SDL_MIXER_VERSION(x):
     x.major = SDL_MIXER_MAJOR_VERSION
@@ -106,7 +108,6 @@ MIX_VERSION = SDL_MIXER_VERSION
 SDL_MIXER_COMPILEDVERSION = SDL_VERSIONNUM(SDL_MIXER_MAJOR_VERSION, SDL_MIXER_MINOR_VERSION, SDL_MIXER_PATCHLEVEL)
 SDL_MIXER_VERSION_ATLEAST = lambda x, y, z: (SDL_MIXER_COMPILEDVERSION >= SDL_VERSIONNUM(x, y, z))
 
-Mix_Linked_Version = _bind("Mix_Linked_Version", None, POINTER(SDL_version))
 MIX_InitFlags = c_int
 MIX_INIT_FLAC = 0x00000001
 MIX_INIT_MOD =  0x00000002
@@ -114,24 +115,6 @@ MIX_INIT_MP3 = 0x00000008
 MIX_INIT_OGG = 0x000000010
 MIX_INIT_MID = 0x00000020
 MIX_INIT_OPUS = 0x00000040
-
-Mix_Init = _bind("Mix_Init", [c_int], c_int)
-Mix_Quit = _bind("Mix_Quit")
-
-MIX_CHANNELS = 8
-MIX_DEFAULT_FREQUENCY = 22050
-if SDL_BYTEORDER == SDL_LIL_ENDIAN:
-    MIX_DEFAULT_FORMAT = AUDIO_S16LSB
-else:
-    MIX_DEFAULT_FORMAT = AUDIO_S16MSB
-MIX_DEFAULT_CHANNELS = 2
-MIX_MAX_VOLUME = SDL_MIX_MAXVOLUME
-
-class Mix_Chunk(Structure):
-    _fields_ = [("allocated", c_int),
-                ("abuf", POINTER(Uint8)),
-                ("alen", Uint32),
-                ("volume", Uint8)]
 
 Mix_Fading = c_int
 MIX_NO_FADING = 0
@@ -150,93 +133,374 @@ MUS_FLAC = 9
 MUS_MODPLUG_UNUSED = 10
 MUS_OPUS = 11
 
+MIX_CHANNELS = 8
+MIX_DEFAULT_FREQUENCY = 22050
+if SDL_BYTEORDER == SDL_LIL_ENDIAN:
+    MIX_DEFAULT_FORMAT = AUDIO_S16LSB
+else:
+    MIX_DEFAULT_FORMAT = AUDIO_S16MSB
+MIX_DEFAULT_CHANNELS = 2
+MIX_MAX_VOLUME = SDL_MIX_MAXVOLUME
+
+MIX_CHANNEL_POST = -2
+MIX_EFFECTSMAXSPEED = "MIX_EFFECTSMAXSPEED"
+
+class Mix_Chunk(Structure):
+    _fields_ = [("allocated", c_int),
+                ("abuf", _P(Uint8)),
+                ("alen", Uint32),
+                ("volume", Uint8)]
+
 class Mix_Music(c_void_p):
     pass
 
-Mix_OpenAudio = _bind("Mix_OpenAudio", [c_int, Uint16, c_int, c_int], c_int)
-Mix_OpenAudioDevice = _bind("Mix_OpenAudioDevice", [c_int, Uint16, c_int, c_int, c_char_p, c_int], c_int, added='2.0.2')
-Mix_AllocateChannels = _bind("Mix_AllocateChannels", [c_int], c_int)
-Mix_QuerySpec = _bind("Mix_QuerySpec", [POINTER(c_int), POINTER(Uint16), POINTER(c_int)], c_int)
-Mix_LoadWAV_RW = _bind("Mix_LoadWAV_RW", [POINTER(SDL_RWops), c_int], POINTER(Mix_Chunk))
-Mix_LoadWAV = lambda fname: Mix_LoadWAV_RW(SDL_RWFromFile(fname, b"rb"), 1)
-Mix_LoadMUS = _bind("Mix_LoadMUS", [c_char_p], POINTER(Mix_Music))
-Mix_LoadMUS_RW = _bind("Mix_LoadMUS_RW", [POINTER(SDL_RWops)], POINTER(Mix_Music))
-Mix_LoadMUSType_RW = _bind("Mix_LoadMUSType_RW", [POINTER(SDL_RWops), Mix_MusicType, c_int], POINTER(Mix_Music))
-Mix_QuickLoad_WAV = _bind("Mix_QuickLoad_WAV", [POINTER(Uint8)], POINTER(Mix_Chunk))
-Mix_QuickLoad_RAW = _bind("Mix_QuickLoad_RAW", [POINTER(Uint8), Uint32], POINTER(Mix_Chunk))
-Mix_FreeChunk = _bind("Mix_FreeChunk", [POINTER(Mix_Chunk)])
-Mix_FreeMusic = _bind("Mix_FreeMusic", [POINTER(Mix_Music)])
-Mix_GetNumChunkDecoders = _bind("Mix_GetNumChunkDecoders", None, c_int)
-Mix_GetChunkDecoder = _bind("Mix_GetChunkDecoder", [c_int], c_char_p)
-Mix_HasChunkDecoder = _bind("Mix_HasChunkDecoder", [c_char_p], SDL_bool, added='2.0.2')
-Mix_GetNumMusicDecoders = _bind("Mix_GetNumMusicDecoders", None, c_int)
-Mix_GetMusicDecoder = _bind("Mix_GetMusicDecoder", [c_int], c_char_p)
-#Mix_HasMusicDecoder = _bind("Mix_HasMusicDecoder", [c_char_p], SDL_bool) # not actually implemented in SDL_mixer
-Mix_GetMusicType = _bind("Mix_GetMusicType", [POINTER(Mix_Music)], Mix_MusicType)
-mix_func = CFUNCTYPE(None, c_void_p, POINTER(Uint8), c_int)
-Mix_SetPostMix = _bind("Mix_SetPostMix", [mix_func, c_void_p])
-Mix_HookMusic = _bind("Mix_HookMusic", [mix_func, c_void_p])
+mix_func = CFUNCTYPE(None, c_void_p, _P(Uint8), c_int)
 music_finished = CFUNCTYPE(None)
-Mix_HookMusicFinished = _bind("Mix_HookMusicFinished", [music_finished])
-Mix_GetMusicHookData = _bind("Mix_GetMusicHookData", None, c_void_p)
 channel_finished = CFUNCTYPE(None, c_int)
-Mix_ChannelFinished = _bind("Mix_ChannelFinished", [channel_finished])
-MIX_CHANNEL_POST = -2
 Mix_EffectFunc_t = CFUNCTYPE(None, c_int, c_void_p, c_int, c_void_p)
 Mix_EffectDone_t = CFUNCTYPE(None, c_int, c_void_p)
-Mix_RegisterEffect = _bind("Mix_RegisterEffect", [c_int, Mix_EffectFunc_t, Mix_EffectDone_t, c_void_p], c_int)
-Mix_UnregisterEffect = _bind("Mix_UnregisterEffect", [c_int, Mix_EffectFunc_t], c_int)
-Mix_UnregisterAllEffects = _bind("Mix_UnregisterAllEffects", [c_int])
-MIX_EFFECTSMAXSPEED = "MIX_EFFECTSMAXSPEED"
-Mix_SetPanning = _bind("Mix_SetPanning", [c_int, Uint8, Uint8], c_int)
-Mix_SetPosition = _bind("Mix_SetPosition", [c_int, Sint16, Uint8], c_int)
-Mix_SetDistance = _bind("Mix_SetDistance", [c_int, Uint8])
-Mix_SetReverseStereo = _bind("Mix_SetReverseStereo", [c_int, c_int], c_int)
-Mix_ReserveChannels = _bind("Mix_ReserveChannels", [c_int], c_int)
-Mix_GroupChannel = _bind("Mix_GroupChannel", [c_int, c_int], c_int)
-Mix_GroupChannels = _bind("Mix_GroupChannels", [c_int, c_int, c_int], c_int)
-Mix_GroupAvailable = _bind("Mix_GroupAvailable", [c_int], c_int)
-Mix_GroupCount = _bind("Mix_GroupCount", [c_int], c_int)
-Mix_GroupOldest = _bind("Mix_GroupOldest", [c_int], c_int)
-Mix_GroupNewer = _bind("Mix_GroupNewer", [c_int], c_int)
-Mix_PlayChannel = lambda channel, chunk, loops: Mix_PlayChannelTimed(channel, chunk, loops, -1)
-Mix_PlayChannelTimed = _bind("Mix_PlayChannelTimed", [c_int, POINTER(Mix_Chunk), c_int, c_int], c_int)
-Mix_PlayMusic = _bind("Mix_PlayMusic", [POINTER(Mix_Music), c_int], c_int)
-Mix_FadeInMusic = _bind("Mix_FadeInMusic", [POINTER(Mix_Music), c_int, c_int], c_int)
-Mix_FadeInMusicPos = _bind("Mix_FadeInMusicPos", [POINTER(Mix_Music), c_int, c_int, c_double], c_int)
-Mix_FadeInChannel = lambda channel, chunk, loops, ms: Mix_FadeInChannelTimed(channel, chunk, loops, ms, -1)
-Mix_FadeInChannelTimed = _bind("Mix_FadeInChannelTimed", [c_int, POINTER(Mix_Chunk), c_int, c_int, c_int], c_int)
-Mix_Volume = _bind("Mix_Volume", [c_int, c_int], c_int)
-Mix_VolumeChunk = _bind("Mix_VolumeChunk", [POINTER(Mix_Chunk), c_int], c_int)
-Mix_VolumeMusic = _bind("Mix_VolumeMusic", [c_int], c_int)
-Mix_HaltChannel = _bind("Mix_HaltChannel", [c_int], c_int)
-Mix_HaltGroup = _bind("Mix_HaltGroup", [c_int], c_int)
-Mix_HaltMusic = _bind("Mix_HaltMusic", None, c_int)
-Mix_ExpireChannel = _bind("Mix_ExpireChannel", [c_int, c_int], c_int)
-Mix_FadeOutChannel = _bind("Mix_FadeOutChannel", [c_int, c_int], c_int)
-Mix_FadeOutGroup = _bind("Mix_FadeOutGroup", [c_int, c_int], c_int)
-Mix_FadeOutMusic = _bind("Mix_FadeOutMusic", [c_int], c_int)
-Mix_FadingMusic = _bind("Mix_FadingMusic", None, Mix_Fading)
-Mix_FadingChannel = _bind("Mix_FadingChannel", [c_int], Mix_Fading)
-Mix_Pause = _bind("Mix_Pause", [c_int])
-Mix_Resume = _bind("Mix_Resume", [c_int])
-Mix_Paused = _bind("Mix_Paused", [c_int], c_int)
-Mix_PauseMusic = _bind("Mix_PauseMusic")
-Mix_ResumeMusic = _bind("Mix_ResumeMusic")
-Mix_RewindMusic = _bind("Mix_RewindMusic")
-Mix_PausedMusic = _bind("Mix_PausedMusic", None, c_int)
-Mix_SetMusicPosition = _bind("Mix_SetMusicPosition", [c_double], c_int)
-Mix_Playing = _bind("Mix_Playing", [c_int], c_int)
-Mix_PlayingMusic = _bind("Mix_PlayingMusic", None, c_int)
-Mix_SetMusicCMD = _bind("Mix_SetMusicCMD", [c_char_p], c_int)
-Mix_SetSynchroValue = _bind("Mix_SetSynchroValue", [c_int], c_int)
-Mix_GetSynchroValue = _bind("Mix_GetSynchroValue", None, c_int)
-Mix_SetSoundFonts = _bind("Mix_SetSoundFonts", [c_char_p], c_int)
-Mix_GetSoundFonts = _bind("Mix_GetSoundFonts", None, c_char_p)
 soundfont_function = CFUNCTYPE(c_int, c_char_p, c_void_p)
-Mix_EachSoundFont = _bind("Mix_EachSoundFont", [soundfont_function, c_void_p], c_int)
-Mix_GetChunk = _bind("Mix_GetChunk", [c_int], POINTER(Mix_Chunk))
-Mix_CloseAudio = _bind("Mix_CloseAudio")
+
+
+# Raw ctypes function definitions
+
+_funcdefs = [
+    SDLFunc("Mix_Linked_Version", None, _P(SDL_version)),
+    SDLFunc("Mix_Init", [c_int], c_int),
+    SDLFunc("Mix_Quit"),
+    SDLFunc("Mix_OpenAudio", [c_int, Uint16, c_int, c_int], c_int),
+    SDLFunc("Mix_OpenAudioDevice", [c_int, Uint16, c_int, c_int, c_char_p, c_int], c_int, added='2.0.2'),
+    SDLFunc("Mix_AllocateChannels", [c_int], c_int),
+    SDLFunc("Mix_QuerySpec", [_P(c_int), _P(Uint16), _P(c_int)], c_int),
+    SDLFunc("Mix_LoadWAV_RW", [_P(SDL_RWops), c_int], _P(Mix_Chunk)),
+    SDLFunc("Mix_LoadMUS", [c_char_p], _P(Mix_Music)),
+    SDLFunc("Mix_LoadMUS_RW", [_P(SDL_RWops)], _P(Mix_Music)),
+    SDLFunc("Mix_LoadMUSType_RW", [_P(SDL_RWops), Mix_MusicType, c_int], _P(Mix_Music)),
+    SDLFunc("Mix_QuickLoad_WAV", [_P(Uint8)], _P(Mix_Chunk)),
+    SDLFunc("Mix_QuickLoad_RAW", [_P(Uint8), Uint32], _P(Mix_Chunk)),
+    SDLFunc("Mix_FreeChunk", [_P(Mix_Chunk)]),
+    SDLFunc("Mix_FreeMusic", [_P(Mix_Music)]),
+    SDLFunc("Mix_GetNumChunkDecoders", None, c_int),
+    SDLFunc("Mix_GetChunkDecoder", [c_int], c_char_p),
+    SDLFunc("Mix_HasChunkDecoder", [c_char_p], SDL_bool, added='2.0.2'),
+    SDLFunc("Mix_GetNumMusicDecoders", None, c_int),
+    SDLFunc("Mix_GetMusicDecoder", [c_int], c_char_p),
+    SDLFunc("Mix_GetMusicType", [_P(Mix_Music)], Mix_MusicType),
+    SDLFunc("Mix_SetPostMix", [mix_func, c_void_p]),
+    SDLFunc("Mix_HookMusic", [mix_func, c_void_p]),
+    SDLFunc("Mix_HookMusicFinished", [music_finished]),
+    SDLFunc("Mix_GetMusicHookData", None, c_void_p),
+    SDLFunc("Mix_ChannelFinished", [channel_finished]),
+    SDLFunc("Mix_RegisterEffect", [c_int, Mix_EffectFunc_t, Mix_EffectDone_t, c_void_p], c_int),
+    SDLFunc("Mix_UnregisterEffect", [c_int, Mix_EffectFunc_t], c_int),
+    SDLFunc("Mix_UnregisterAllEffects", [c_int]),
+    SDLFunc("Mix_SetPanning", [c_int, Uint8, Uint8], c_int),
+    SDLFunc("Mix_SetPosition", [c_int, Sint16, Uint8], c_int),
+    SDLFunc("Mix_SetDistance", [c_int, Uint8]),
+    SDLFunc("Mix_SetReverseStereo", [c_int, c_int], c_int),
+    SDLFunc("Mix_ReserveChannels", [c_int], c_int),
+    SDLFunc("Mix_GroupChannel", [c_int, c_int], c_int),
+    SDLFunc("Mix_GroupChannels", [c_int, c_int, c_int], c_int),
+    SDLFunc("Mix_GroupAvailable", [c_int], c_int),
+    SDLFunc("Mix_GroupCount", [c_int], c_int),
+    SDLFunc("Mix_GroupOldest", [c_int], c_int),
+    SDLFunc("Mix_GroupNewer", [c_int], c_int),
+    SDLFunc("Mix_PlayChannelTimed", [c_int, _P(Mix_Chunk), c_int, c_int], c_int),
+    SDLFunc("Mix_PlayMusic", [_P(Mix_Music), c_int], c_int),
+    SDLFunc("Mix_FadeInMusic", [_P(Mix_Music), c_int, c_int], c_int),
+    SDLFunc("Mix_FadeInMusicPos", [_P(Mix_Music), c_int, c_int, c_double], c_int),
+    SDLFunc("Mix_FadeInChannelTimed", [c_int, _P(Mix_Chunk), c_int, c_int, c_int], c_int),
+    SDLFunc("Mix_Volume", [c_int, c_int], c_int),
+    SDLFunc("Mix_VolumeChunk", [_P(Mix_Chunk), c_int], c_int),
+    SDLFunc("Mix_VolumeMusic", [c_int], c_int),
+    SDLFunc("Mix_HaltChannel", [c_int], c_int),
+    SDLFunc("Mix_HaltGroup", [c_int], c_int),
+    SDLFunc("Mix_HaltMusic", None, c_int),
+    SDLFunc("Mix_ExpireChannel", [c_int, c_int], c_int),
+    SDLFunc("Mix_FadeOutChannel", [c_int, c_int], c_int),
+    SDLFunc("Mix_FadeOutGroup", [c_int, c_int], c_int),
+    SDLFunc("Mix_FadeOutMusic", [c_int], c_int),
+    SDLFunc("Mix_FadingMusic", None, Mix_Fading),
+    SDLFunc("Mix_FadingChannel", [c_int], Mix_Fading),
+    SDLFunc("Mix_Pause", [c_int]),
+    SDLFunc("Mix_Resume", [c_int]),
+    SDLFunc("Mix_Paused", [c_int], c_int),
+    SDLFunc("Mix_PauseMusic"),
+    SDLFunc("Mix_ResumeMusic"),
+    SDLFunc("Mix_RewindMusic"),
+    SDLFunc("Mix_PausedMusic", None, c_int),
+    SDLFunc("Mix_SetMusicPosition", [c_double], c_int),
+    SDLFunc("Mix_Playing", [c_int], c_int),
+    SDLFunc("Mix_PlayingMusic", None, c_int),
+    SDLFunc("Mix_SetMusicCMD", [c_char_p], c_int),
+    SDLFunc("Mix_SetSynchroValue", [c_int], c_int),
+    SDLFunc("Mix_GetSynchroValue", None, c_int),
+    SDLFunc("Mix_SetSoundFonts", [c_char_p], c_int),
+    SDLFunc("Mix_GetSoundFonts", None, c_char_p),
+    SDLFunc("Mix_EachSoundFont", [soundfont_function, c_void_p], c_int),
+    SDLFunc("Mix_GetChunk", [c_int], _P(Mix_Chunk)),
+    SDLFunc("Mix_CloseAudio"),
+]
+_funcs = {}
+for f in _funcdefs:
+    _funcs[f.name] = _bind(f.name, f.args, f.returns, f.added)
+
+
+# Python wrapper functions
+
+def Mix_Linked_Version():
+    return _funcs["Mix_Linked_Version"]()
+
+def Mix_Init(flags):
+    return _funcs["Mix_Init"](flags)
+
+def Mix_Quit():
+    return _funcs["Mix_Quit"]()
+
+
+def Mix_OpenAudio(frequency, format, channels, chunksize):
+    return _funcs["Mix_OpenAudio"](frequency, format, channels, chunksize)
+
+def Mix_OpenAudioDevice(frequency, format, channels, chunksize, device, allowed_changes):
+    return _funcs["Mix_OpenAudioDevice"](
+        frequency, format, channels, chunksize, device, allowed_changes
+    )
+
+def Mix_AllocateChannels(numchans):
+    return _funcs["Mix_AllocateChannels"](numchans)
+
+def Mix_QuerySpec(frequency, format, channels):
+    return _funcs["Mix_QuerySpec"](frequency, format, channels)
+
+
+def Mix_LoadWAV_RW(src, freesrc):
+    return _funcs["Mix_LoadWAV_RW"](src, freesrc)
+
+def Mix_LoadWAV(file):
+    return Mix_LoadWAV_RW(SDL_RWFromFile(file, b"rb"), 1)
+
+def Mix_LoadMUS(file):
+    return _funcs["Mix_LoadMUS"](file)
+
+def Mix_LoadMUS_RW(src, freesrc):
+    return _funcs["Mix_LoadMUS_RW"](src, freesrc)
+
+def Mix_LoadMUSType_RW(src, type, freesrc):
+    return _funcs["Mix_LoadMUSType_RW"](src, type, freesrc)
+
+def Mix_QuickLoad_WAV(mem):
+    return _funcs["Mix_QuickLoad_WAV"](mem)
+
+def Mix_QuickLoad_RAW(mem, len):
+    return _funcs["Mix_QuickLoad_RAW"](mem, len)
+
+def Mix_FreeChunk(chunk):
+    return _funcs["Mix_FreeChunk"](chunk)
+
+def Mix_FreeMusic(music):
+    return _funcs["Mix_FreeMusic"](music)
+
+
+def Mix_GetNumChunkDecoders():
+    return _funcs["Mix_GetNumChunkDecoders"]()
+
+def Mix_GetChunkDecoder(index):
+    return _funcs["Mix_GetChunkDecoder"](index)
+
+def Mix_HasChunkDecoder(name):
+    return _funcs["Mix_HasChunkDecoder"](name)
+
+def Mix_GetNumMusicDecoders():
+    return _funcs["Mix_GetNumMusicDecoders"]()
+
+def Mix_GetMusicDecoder(index):
+    return _funcs["Mix_GetMusicDecoder"](index)
+
+def Mix_GetMusicType(music):
+    return _funcs["Mix_GetMusicType"](music)
+
+
+def Mix_SetPostMix(mix_func, arg):
+    return _funcs["Mix_SetPostMix"](mix_func, arg)
+
+def Mix_HookMusic(mix_func, arg):
+    return _funcs["Mix_HookMusic"](mix_func, arg)
+
+def Mix_HookMusicFinished(music_finished):
+    return _funcs["Mix_HookMusicFinished"](music_finished)
+
+def Mix_GetMusicHookData():
+    return _funcs["Mix_GetMusicHookData"]()
+
+def Mix_ChannelFinished(channel_finished):
+    return _funcs["Mix_ChannelFinished"](channel_finished)
+
+
+def Mix_RegisterEffect(chan, f, d, arg):
+    return _funcs["Mix_RegisterEffect"](chan, f, d, arg)
+
+def Mix_UnregisterEffect(channel, f):
+    return _funcs["Mix_UnregisterEffect"](channel, f)
+
+def Mix_UnregisterAllEffects(channel):
+    return _funcs["Mix_UnregisterAllEffects"](channel)
+
+
+def Mix_SetPanning(channel, left, right):
+    return _funcs["Mix_SetPanning"](channel, left, right)
+
+def Mix_SetPosition(channel, angle, distance):
+    return _funcs["Mix_SetPosition"](channel, angle, distance)
+
+def Mix_SetDistance(channel, distance):
+    return _funcs["Mix_SetDistance"](channel, distance)
+
+def Mix_SetReverseStereo(channel, flip):
+    return _funcs["Mix_SetReverseStereo"](channel, flip)
+
+def Mix_ReserveChannels(num):
+    return _funcs["Mix_ReserveChannels"](num)
+
+
+def Mix_GroupChannel(which, tag):
+    return _funcs["Mix_GroupChannel"](which, tag)
+
+def Mix_GroupChannels(from, to, tag):
+    return _funcs["Mix_GroupChannels"](from, to, tag)
+
+def Mix_GroupAvailable(tag):
+    return _funcs["Mix_GroupAvailable"](tag)
+
+def Mix_GroupCount(tag):
+    return _funcs["Mix_GroupCount"](tag)
+
+def Mix_GroupOldest(tag):
+    return _funcs["Mix_GroupOldest"](tag)
+
+def Mix_GroupNewer(tag):
+    return _funcs["Mix_GroupNewer"](tag)
+
+
+def Mix_PlayChannelTimed(channel, chunk, loops, ticks):
+    return _funcs["Mix_PlayChannelTimed"](channel, chunk, loops, ticks)
+
+def Mix_PlayChannel(channel, chunk, loops):
+    return Mix_PlayChannelTimed(channel, chunk, loops, -1)
+
+def Mix_PlayMusic(music, loops):
+    return _funcs["Mix_PlayMusic"](music, loops)
+
+
+def Mix_FadeInMusic(music, loops, ms):
+    return _funcs["Mix_FadeInMusic"](music, loops, ms)
+
+def Mix_FadeInMusicPos(music, loops, ms, position):
+    return _funcs["Mix_FadeInMusicPos"](music, loops, ms, position)
+
+def Mix_FadeInChannelTimed(channel, chunk, loops, ms, ticks):
+    return _funcs["Mix_FadeInChannelTimed"](channel, chunk, loops, ms, ticks)
+
+def Mix_FadeInChannel(channel, chunk, loops, ms):
+    return Mix_FadeInChannelTimed(channel, chunk, loops, ms, -1)
+
+
+def Mix_Volume(channel, volume):
+    return _funcs["Mix_Volume"](channel, volume)
+
+def Mix_VolumeChunk(chunk, volume):
+    return _funcs["Mix_VolumeChunk"](chunk, volume)
+
+def Mix_VolumeMusic(volume):
+    return _funcs["Mix_VolumeMusic"](volume)
+
+
+def Mix_HaltChannel(channel):
+    return _funcs["Mix_HaltChannel"](channel)
+
+def Mix_HaltGroup(tag):
+    return _funcs["Mix_HaltGroup"](tag)
+
+def Mix_HaltMusic():
+    return _funcs["Mix_HaltMusic"]()
+
+def Mix_ExpireChannel(channel, ticks):
+    return _funcs["Mix_ExpireChannel"](channel, ticks)
+
+
+def Mix_FadeOutChannel(which, ms):
+    return _funcs["Mix_FadeOutChannel"](which, ms)
+
+def Mix_FadeOutGroup(tag, ms):
+    return _funcs["Mix_FadeOutGroup"](tag, ms)
+
+def Mix_FadeOutMusic(ms):
+    return _funcs["Mix_FadeOutMusic"](ms)
+
+def Mix_FadingMusic():
+    return _funcs["Mix_FadingMusic"]()
+
+def Mix_FadingChannel(which):
+    return _funcs["Mix_FadingChannel"](which)
+
+
+def Mix_Pause(channel):
+    return _funcs["Mix_Pause"](channel)
+
+def Mix_Resume(channel):
+    return _funcs["Mix_Resume"](channel)
+
+def Mix_Paused(channel):
+    return _funcs["Mix_Paused"](channel)
+
+def Mix_PauseMusic():
+    return _funcs["Mix_PauseMusic"]()
+
+def Mix_ResumeMusic():
+    return _funcs["Mix_ResumeMusic"]()
+
+def Mix_RewindMusic():
+    return _funcs["Mix_RewindMusic"]()
+
+def Mix_PausedMusic():
+    return _funcs["Mix_PausedMusic"]()
+
+
+def Mix_SetMusicPosition(position):
+    return _funcs["Mix_SetMusicPosition"](position)
+
+def Mix_Playing(channel):
+    return _funcs["Mix_Playing"](channel)
+
+def Mix_PlayingMusic():
+    return _funcs["Mix_PlayingMusic"]()
+
+def Mix_SetMusicCMD(command):
+    return _funcs["Mix_SetMusicCMD"](command)
+
+
+def Mix_SetSynchroValue(value):
+    return _funcs["Mix_SetSynchroValue"](value)
+
+def Mix_GetSynchroValue():
+    return _funcs["Mix_GetSynchroValue"]()
+
+def Mix_SetSoundFonts(paths):
+    return _funcs["Mix_SetSoundFonts"](paths)
+
+def Mix_GetSoundFonts():
+    return _funcs["Mix_GetSoundFonts"]()
+
+def Mix_EachSoundFont(function, data):
+    return _funcs["Mix_EachSoundFont"](function, data)
+
+
+def Mix_GetChunk(channel):
+    return _funcs["Mix_GetChunk"](channel)
+
+def Mix_CloseAudio():
+    return _funcs["Mix_CloseAudio"]()
+
+
 Mix_SetError = SDL_SetError
 Mix_GetError = SDL_GetError
 Mix_ClearError = SDL_ClearError

--- a/sdl2/sdlttf.py
+++ b/sdl2/sdlttf.py
@@ -1,6 +1,7 @@
 import os
 from ctypes import Structure, POINTER, c_int, c_long, c_char_p, c_void_p
-from .dll import DLL
+from ctypes import POINTER as _P
+from .dll import DLL, SDLFunc
 from .version import SDL_version, SDL_VERSIONNUM
 from .rwops import SDL_RWops
 from .stdinc import Uint16, Uint32
@@ -65,10 +66,12 @@ def get_dll_file():
 
 _bind = dll.bind_function
 
+
+# Constants, enums, type definitions, and macros
+
 SDL_TTF_MAJOR_VERSION = 2
 SDL_TTF_MINOR_VERSION = 0
 SDL_TTF_PATCHLEVEL = 15
-
 
 def SDL_TTF_VERSION(x):
     x.major = SDL_TTF_MAJOR_VERSION
@@ -83,77 +86,236 @@ TTF_VERSION = SDL_TTF_VERSION
 SDL_TTF_COMPILEDVERSION = SDL_VERSIONNUM(SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, SDL_TTF_PATCHLEVEL)
 SDL_TTF_VERSION_ATLEAST = lambda x, y, z: (SDL_TTF_COMPILEDVERSION >= SDL_VERSIONNUM(x, y, z))
 
-TTF_Linked_Version = _bind("TTF_Linked_Version", None, POINTER(SDL_version))
 UNICODE_BOM_NATIVE = 0xFEFF
 UNICODE_BOM_SWAPPED = 0xFFFE
-
-TTF_ByteSwappedUNICODE = _bind("TTF_ByteSwappedUNICODE", [c_int])
-
-
-class TTF_Font(c_void_p):
-    pass
-
-TTF_Init = _bind("TTF_Init", None, c_int)
-TTF_OpenFont = _bind("TTF_OpenFont", [c_char_p, c_int], POINTER(TTF_Font))
-TTF_OpenFontIndex = _bind("TTF_OpenFontIndex", [c_char_p, c_int, c_long], POINTER(TTF_Font))
-TTF_OpenFontRW = _bind("TTF_OpenFontRW", [POINTER(SDL_RWops), c_int, c_int], POINTER(TTF_Font))
-TTF_OpenFontIndexRW = _bind("TTF_OpenFontIndexRW", [POINTER(SDL_RWops), c_int, c_int, c_long], POINTER(TTF_Font))
 
 TTF_STYLE_NORMAL = 0x00
 TTF_STYLE_BOLD = 0x01
 TTF_STYLE_ITALIC = 0x02
 TTF_STYLE_UNDERLINE = 0x04
 TTF_STYLE_STRIKETHROUGH = 0x08
-TTF_GetFontStyle = _bind("TTF_GetFontStyle", [POINTER(TTF_Font)], c_int)
-TTF_SetFontStyle = _bind("TTF_SetFontStyle", [POINTER(TTF_Font), c_int])
-TTF_GetFontOutline = _bind("TTF_GetFontOutline", [POINTER(TTF_Font)], c_int)
-TTF_SetFontOutline = _bind("TTF_SetFontOutline", [POINTER(TTF_Font), c_int])
 
 TTF_HINTING_NORMAL = 0
 TTF_HINTING_LIGHT = 1
 TTF_HINTING_MONO = 2
 TTF_HINTING_NONE = 3
-TTF_GetFontHinting = _bind("TTF_GetFontHinting", [POINTER(TTF_Font)], c_int)
-TTF_SetFontHinting = _bind("TTF_SetFontHinting", [POINTER(TTF_Font), c_int])
 
-TTF_FontHeight = _bind("TTF_FontHeight", [POINTER(TTF_Font)], c_int)
-TTF_FontAscent = _bind("TTF_FontAscent", [POINTER(TTF_Font)], c_int)
-TTF_FontDescent = _bind("TTF_FontDescent", [POINTER(TTF_Font)], c_int)
-TTF_FontLineSkip = _bind("TTF_FontLineSkip", [POINTER(TTF_Font)], c_int)
-TTF_GetFontKerning = _bind("TTF_GetFontKerning", [POINTER(TTF_Font)], c_int)
-TTF_SetFontKerning = _bind("TTF_SetFontKerning", [POINTER(TTF_Font), c_int])
-TTF_FontFaces = _bind("TTF_FontFaces", [POINTER(TTF_Font)], c_long)
-TTF_FontFaceIsFixedWidth = _bind("TTF_FontFaceIsFixedWidth", [POINTER(TTF_Font)], c_int)
-TTF_FontFaceFamilyName = _bind("TTF_FontFaceFamilyName", [POINTER(TTF_Font)], c_char_p)
-TTF_FontFaceStyleName = _bind("TTF_FontFaceStyleName", [POINTER(TTF_Font)], c_char_p)
-TTF_GlyphIsProvided = _bind("TTF_GlyphIsProvided", [POINTER(TTF_Font), Uint16], c_int)
-TTF_GlyphMetrics = _bind("TTF_GlyphMetrics", [POINTER(TTF_Font), Uint16, POINTER(c_int), POINTER(c_int), POINTER(c_int), POINTER(c_int), POINTER(c_int)], c_int)
-TTF_SizeText = _bind("TTF_SizeText", [POINTER(TTF_Font), c_char_p, POINTER(c_int), POINTER(c_int)], c_int)
-TTF_SizeUTF8 = _bind("TTF_SizeUTF8", [POINTER(TTF_Font), c_char_p, POINTER(c_int), POINTER(c_int)], c_int)
-TTF_SizeUNICODE = _bind("TTF_SizeUNICODE", [POINTER(TTF_Font), POINTER(Uint16), POINTER(c_int), POINTER(c_int)], c_int)
-TTF_RenderText_Solid = _bind("TTF_RenderText_Solid", [POINTER(TTF_Font), c_char_p, SDL_Color], POINTER(SDL_Surface))
-TTF_RenderUTF8_Solid = _bind("TTF_RenderUTF8_Solid", [POINTER(TTF_Font), c_char_p, SDL_Color], POINTER(SDL_Surface))
-TTF_RenderUNICODE_Solid = _bind("TTF_RenderUNICODE_Solid", [POINTER(TTF_Font), POINTER(Uint16), SDL_Color], POINTER(SDL_Surface))
-TTF_RenderGlyph_Solid = _bind("TTF_RenderGlyph_Solid", [POINTER(TTF_Font), Uint16, SDL_Color], POINTER(SDL_Surface))
-TTF_RenderText_Shaded = _bind("TTF_RenderText_Shaded", [POINTER(TTF_Font), c_char_p, SDL_Color, SDL_Color], POINTER(SDL_Surface))
-TTF_RenderUTF8_Shaded = _bind("TTF_RenderUTF8_Shaded", [POINTER(TTF_Font), c_char_p, SDL_Color, SDL_Color], POINTER(SDL_Surface))
-TTF_RenderUNICODE_Shaded = _bind("TTF_RenderUNICODE_Shaded", [POINTER(TTF_Font), POINTER(Uint16), SDL_Color, SDL_Color], POINTER(SDL_Surface))
-TTF_RenderGlyph_Shaded = _bind("TTF_RenderGlyph_Shaded", [POINTER(TTF_Font), Uint16, SDL_Color, SDL_Color], POINTER(SDL_Surface))
-TTF_RenderText_Blended = _bind("TTF_RenderText_Blended", [POINTER(TTF_Font), c_char_p, SDL_Color], POINTER(SDL_Surface))
-TTF_RenderUTF8_Blended = _bind("TTF_RenderUTF8_Blended", [POINTER(TTF_Font), c_char_p, SDL_Color], POINTER(SDL_Surface))
-TTF_RenderUNICODE_Blended = _bind("TTF_RenderUNICODE_Blended", [POINTER(TTF_Font), POINTER(Uint16), SDL_Color], POINTER(SDL_Surface))
-TTF_RenderText_Blended_Wrapped = _bind("TTF_RenderText_Blended_Wrapped", [POINTER(TTF_Font), c_char_p, SDL_Color, Uint32], POINTER(SDL_Surface))
-TTF_RenderUTF8_Blended_Wrapped = _bind("TTF_RenderUTF8_Blended_Wrapped", [POINTER(TTF_Font), c_char_p, SDL_Color, Uint32], POINTER(SDL_Surface))
-TTF_RenderUNICODE_Blended_Wrapped = _bind("TTF_RenderUNICODE_Blended_Wrapped", [POINTER(TTF_Font), POINTER(Uint16), SDL_Color, Uint32], POINTER(SDL_Surface))
-TTF_RenderGlyph_Blended = _bind("TTF_RenderGlyph_Blended", [POINTER(TTF_Font), Uint16, SDL_Color], POINTER(SDL_Surface))
+class TTF_Font(c_void_p):
+    pass
+
+
+# Raw ctypes function definitions
+
+_funcdefs = [
+    SDLFunc("TTF_Linked_Version", None, _P(SDL_version)),
+    SDLFunc("TTF_ByteSwappedUNICODE", [c_int], None),
+    SDLFunc("TTF_Init", None, c_int),
+    SDLFunc("TTF_OpenFont", [c_char_p, c_int], _P(TTF_Font)),
+    SDLFunc("TTF_OpenFontIndex", [c_char_p, c_int, c_long], _P(TTF_Font)),
+    SDLFunc("TTF_OpenFontRW", [_P(SDL_RWops), c_int, c_int], _P(TTF_Font)),
+    SDLFunc("TTF_OpenFontIndexRW", [_P(SDL_RWops), c_int, c_int, c_long], _P(TTF_Font)),
+    SDLFunc("TTF_GetFontStyle", [_P(TTF_Font)], c_int),
+    SDLFunc("TTF_SetFontStyle", [_P(TTF_Font), c_int], None),
+    SDLFunc("TTF_GetFontOutline", [_P(TTF_Font)], c_int),
+    SDLFunc("TTF_SetFontOutline", [_P(TTF_Font), c_int], None),
+    SDLFunc("TTF_GetFontHinting", [_P(TTF_Font)], c_int),
+    SDLFunc("TTF_SetFontHinting", [_P(TTF_Font), c_int], None),
+    SDLFunc("TTF_FontHeight", [_P(TTF_Font)], c_int),
+    SDLFunc("TTF_FontAscent", [_P(TTF_Font)], c_int),
+    SDLFunc("TTF_FontDescent", [_P(TTF_Font)], c_int),
+    SDLFunc("TTF_FontLineSkip", [_P(TTF_Font)], c_int),
+    SDLFunc("TTF_GetFontKerning", [_P(TTF_Font)], c_int),
+    SDLFunc("TTF_SetFontKerning", [_P(TTF_Font), c_int]),
+    SDLFunc("TTF_FontFaces", [_P(TTF_Font)], c_long),
+    SDLFunc("TTF_FontFaceIsFixedWidth", [_P(TTF_Font)], c_int),
+    SDLFunc("TTF_FontFaceFamilyName", [_P(TTF_Font)], c_char_p),
+    SDLFunc("TTF_FontFaceStyleName", [_P(TTF_Font)], c_char_p),
+    SDLFunc("TTF_GlyphIsProvided", [_P(TTF_Font), Uint16], c_int),
+    SDLFunc("TTF_GlyphMetrics", [_P(TTF_Font), Uint16, _P(c_int), _P(c_int), _P(c_int), _P(c_int), _P(c_int)], c_int),
+    SDLFunc("TTF_SizeText", [_P(TTF_Font), c_char_p, _P(c_int), _P(c_int)], c_int),
+    SDLFunc("TTF_SizeUTF8", [_P(TTF_Font), c_char_p, _P(c_int), _P(c_int)], c_int),
+    SDLFunc("TTF_SizeUNICODE", [_P(TTF_Font), _P(Uint16), _P(c_int), _P(c_int)], c_int),
+    SDLFunc("TTF_RenderText_Solid", [_P(TTF_Font), c_char_p, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderUTF8_Solid", [_P(TTF_Font), c_char_p, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderUNICODE_Solid", [_P(TTF_Font), _P(Uint16), SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderGlyph_Solid", [_P(TTF_Font), Uint16, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderText_Shaded", [_P(TTF_Font), c_char_p, SDL_Color, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderUTF8_Shaded", [_P(TTF_Font), c_char_p, SDL_Color, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderUNICODE_Shaded", [_P(TTF_Font), _P(Uint16), SDL_Color, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderGlyph_Shaded", [_P(TTF_Font), Uint16, SDL_Color, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderText_Blended", [_P(TTF_Font), c_char_p, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderUTF8_Blended", [_P(TTF_Font), c_char_p, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderUNICODE_Blended", [_P(TTF_Font), _P(Uint16), SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderText_Blended_Wrapped", [_P(TTF_Font), c_char_p, SDL_Color, Uint32], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderUTF8_Blended_Wrapped", [_P(TTF_Font), c_char_p, SDL_Color, Uint32], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderUNICODE_Blended_Wrapped", [_P(TTF_Font), _P(Uint16), SDL_Color, Uint32], _P(SDL_Surface)),
+    SDLFunc("TTF_RenderGlyph_Blended", [_P(TTF_Font), Uint16, SDL_Color], _P(SDL_Surface)),
+    SDLFunc("TTF_CloseFont", [_P(TTF_Font)]),
+    SDLFunc("TTF_Quit"),
+    SDLFunc("TTF_WasInit", None, c_int),
+    SDLFunc("TTF_GetFontKerningSize", [_P(TTF_Font), c_int, c_int], c_int),
+    SDLFunc("TTF_GetFontKerningSizeGlyphs", [_P(TTF_Font), Uint16, Uint16], c_int, added='2.0.14'),
+]
+_funcs = {}
+for f in _funcdefs:
+    _funcs[f.name] = _bind(f.name, f.args, f.returns, f.added)
+
+
+# Python wrapper functions
+
+def TTF_Linked_Version():
+    return _funcs["TTF_Linked_Version"]()
+
+def TTF_ByteSwappedUNICODE(swapped):
+    return _funcs["TTF_ByteSwappedUNICODE"](swapped)
+
+def TTF_Init():
+    return _funcs["TTF_Init"]()
+
+
+def TTF_OpenFont(file, ptsize):
+    return _funcs["TTF_OpenFont"](file, ptsize)
+
+def TTF_OpenFontIndex(file, ptsize, index):
+    return _funcs["TTF_OpenFontIndex"](file, ptsize, index)
+
+def TTF_OpenFontRW(src, freesrc, ptsize):
+    return _funcs["TTF_OpenFontRW"](src, freesrc, ptsize)
+
+def TTF_OpenFontIndexRW(src, freesrc, ptsize, index):
+    return _funcs["TTF_OpenFontIndexRW"](src, freesrc, ptsize, index)
+
+
+def TTF_GetFontStyle(font):
+    return _funcs["TTF_GetFontStyle"](font)
+
+def TTF_SetFontStyle(font, style):
+    return _funcs["TTF_SetFontStyle"](font, style)
+
+def TTF_GetFontOutline(font):
+    return _funcs["TTF_GetFontOutline"](font)
+
+def TTF_SetFontOutline(font, outline):
+    return _funcs["TTF_SetFontOutline"](font, outline)
+
+def TTF_GetFontHinting(font):
+    return _funcs["TTF_GetFontHinting"](font)
+
+def TTF_SetFontHinting(font, hinting):
+    return _funcs["TTF_SetFontHinting"](font, hinting)
+
+
+def TTF_FontHeight(font):
+    return _funcs["TTF_FontHeight"](font)
+
+def TTF_FontAscent(font):
+    return _funcs["TTF_FontAscent"](font)
+
+def TTF_FontDescent(font):
+    return _funcs["TTF_FontDescent"](font)
+
+def TTF_FontLineSkip(font):
+    return _funcs["TTF_FontLineSkip"](font)
+
+def TTF_GetFontKerning(font):
+    return _funcs["TTF_GetFontKerning"](font)
+
+def TTF_SetFontKerning(font, allowed):
+    return _funcs["TTF_SetFontKerning"](font, allowed)
+
+def TTF_FontFaces(font):
+    return _funcs["TTF_FontFaces"](font)
+
+def TTF_FontFaceIsFixedWidth(font):
+    return _funcs["TTF_FontFaceIsFixedWidth"](font)
+
+def TTF_FontFaceFamilyName(font):
+    return _funcs["TTF_FontFaceFamilyName"](font)
+
+def TTF_FontFaceStyleName(font):
+    return _funcs["TTF_FontFaceStyleName"](font)
+
+def TTF_GlyphIsProvided(font, ch):
+    return _funcs["TTF_GlyphIsProvided"](font, ch)
+
+def TTF_GlyphMetrics(font, ch, minx, maxx, miny, maxy, advance):
+    return _funcs["TTF_GlyphMetrics"](font, ch, minx, maxx, miny, maxy, advance)
+
+
+def TTF_SizeText(font, text, w, h):
+    return _funcs["TTF_SizeText"](font, text, w, h)
+
+def TTF_SizeUTF8(font, text, w, h):
+    return _funcs["TTF_SizeUTF8"](font, text, w, h)
+
+def TTF_SizeUNICODE(font, text, w, h):
+    return _funcs["TTF_SizeUNICODE"](font, text, w, h)
+
+
+def TTF_RenderText_Solid(font, text, fg):
+    return _funcs["TTF_RenderText_Solid"](font, text, fg)
+
+def TTF_RenderUTF8_Solid(font, text, fg):
+    return _funcs["TTF_RenderUTF8_Solid"](font, text, fg)
+
+def TTF_RenderUNICODE_Solid(font, text, fg):
+    return _funcs["TTF_RenderUNICODE_Solid"](font, text, fg)
+
+def TTF_RenderGlyph_Solid(font, ch, fg):
+    return _funcs["TTF_RenderGlyph_Solid"](font, ch, fg)
+
+def TTF_RenderText_Shaded(font, text, fg, bg):
+    return _funcs["TTF_RenderText_Shaded"](font, text, fg, bg)
+
+def TTF_RenderUTF8_Shaded(font, text, fg, bg):
+    return _funcs["TTF_RenderUTF8_Shaded"](font, text, fg, bg)
+
+def TTF_RenderUNICODE_Shaded(font, text, fg, bg):
+    return _funcs["TTF_RenderUNICODE_Shaded"](font, text, fg, bg)
+
+def TTF_RenderGlyph_Shaded(font, ch, fg, bg):
+    return _funcs["TTF_RenderGlyph_Shaded"](font, ch, fg, bg)
+
+def TTF_RenderText_Blended(font, text, fg):
+    return _funcs["TTF_RenderText_Blended"](font, text, fg)
+
+def TTF_RenderUTF8_Blended(font, text, fg):
+    return _funcs["TTF_RenderUTF8_Blended"](font, text, fg)
+
+def TTF_RenderUNICODE_Blended(font, text, fg):
+    return _funcs["TTF_RenderUNICODE_Blended"](font, text, fg)
+
+def TTF_RenderText_Blended_Wrapped(font, text, fg, wrapLength):
+    return _funcs["TTF_RenderText_Blended_Wrapped"](font, text, fg, wrapLength)
+
+def TTF_RenderUTF8_Blended_Wrapped(font, text, fg, wrapLength):
+    return _funcs["TTF_RenderUTF8_Blended_Wrapped"](font, text, fg, wrapLength)
+
+def TTF_RenderUNICODE_Blended_Wrapped(font, text, fg, wrapLength):
+    return _funcs["TTF_RenderUNICODE_Blended_Wrapped"](font, text, fg, wrapLength)
+
+def TTF_RenderGlyph_Blended(font, ch, fg):
+    return _funcs["TTF_RenderGlyph_Blended"](font, ch, fg)
+
 TTF_RenderText = TTF_RenderText_Shaded
-TTF_RenderUTF = TTF_RenderUTF8_Shaded
+TTF_RenderUTF8 = TTF_RenderUTF8_Shaded
 TTF_RenderUNICODE = TTF_RenderUNICODE_Shaded
-TTF_CloseFont = _bind("TTF_CloseFont", [POINTER(TTF_Font)])
-TTF_Quit = _bind("TTF_Quit")
-TTF_WasInit = _bind("TTF_WasInit", None, c_int)
-TTF_GetFontKerningSize = _bind("TTF_GetFontKerningSize", [POINTER(TTF_Font), c_int, c_int], c_int)
-TTF_GetFontKerningSizeGlyphs = _bind("TTF_GetFontKerningSizeGlyphs", [POINTER(TTF_Font), Uint16, Uint16], c_int, added='2.0.14')
+
+
+def TTF_CloseFont(font):
+    return _funcs["TTF_CloseFont"](font)
+
+def TTF_Quit():
+    return _funcs["TTF_Quit"]()
+
+def TTF_WasInit():
+    return _funcs["TTF_WasInit"]()
+
+def TTF_GetFontKerningSize(font, prev_index, index):
+    return _funcs["TTF_GetFontKerningSize"](font, prev_index, index)
+
+def TTF_GetFontKerningSizeGlyphs(font, previous_ch, ch):
+    return _funcs["TTF_GetFontKerningSizeGlyphs"](font, previous_ch, ch)
+
 TTF_SetError = SDL_SetError
 TTF_GetError = SDL_GetError
-

--- a/sdl2/test/sdlgfx_test.py
+++ b/sdl2/test/sdlgfx_test.py
@@ -10,8 +10,7 @@ sdlgfx = pytest.importorskip("sdl2.sdlgfx")
 
 
 # Framerate test doesn't work right on Github Actions macOS CI
-is_ci_runner = "PYSDL2_DLL_VERSION" in os.environ
-is_macos = sys.platform == "darwin"
+is_macos_ci = sys.platform == "darwin" and "PYSDL2_DLL_VERSION" in os.environ
 
 
 @pytest.fixture(scope="module")
@@ -73,7 +72,7 @@ class TestFramerate(object):
         sdlgfx.SDL_framerateDelay(manager)
         assert sdlgfx.SDL_getFramecount(manager) == 1
 
-    @pytest.skipif(is_macos and is_ci_runner, reason="GHA macOS CI has wonky times")
+    @pytest.mark.skipif(is_macos_ci, reason="Github macOS CI has wonky timing")
     def test_SDL_framerateDelay(self):
         manager = sdlgfx.FPSManager()
         sdlgfx.SDL_initFramerate(manager)

--- a/sdl2/test/sdlgfx_test.py
+++ b/sdl2/test/sdlgfx_test.py
@@ -1,246 +1,192 @@
 import os
 import sys
+from ctypes import c_int, byref
 import pytest
+import sdl2
 from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_VIDEO
-from sdl2 import surface
+from sdl2 import surface, render
 
 sdlgfx = pytest.importorskip("sdl2.sdlgfx")
 
 
-class TestSDLGFX(object):
+@pytest.fixture(scope="module")
+def with_sdl():
+    if SDL_Init(SDL_INIT_VIDEO) != 0:
+        raise RuntimeError("Video subsystem not supported")
+    yield
+    SDL_Quit()
+
+@pytest.fixture
+def test_surf(with_sdl):
+    w, h = 480, 320
+    sf = surface.SDL_CreateRGBSurface(0, w, h, 32, 0, 0, 0, 0)
+    assert isinstance(sf.contents, surface.SDL_Surface)
+    yield sf
+    surface.SDL_FreeSurface(sf)
+
+@pytest.fixture
+def software_renderer(with_sdl):
+    height, width = (480, 320)
+    sdl2.SDL_ClearError()
+    # Create a new SDL surface and make it the target of a new renderer
+    target = surface.SDL_CreateRGBSurface(0, height, width, 32, 0, 0, 0, 0)
+    assert sdl2.SDL_GetError() == b""
+    renderer = render.SDL_CreateSoftwareRenderer(target)
+    assert sdl2.SDL_GetError() == b""
+    # Return the renderer and surface for the test
+    yield (renderer, target)
+    # Free memory for the renderer and surface once we're done
+    sdl2.SDL_DestroyRenderer(renderer)
+    sdl2.SDL_FreeSurface(target)
+
+RED_U32 = 0xFF0000FF
+WHITE_U32 = 0xFFFFFFFF
+
+
+class TestFramerate(object):
     __tags__ = ["sdl", "sdlgfx"]
 
-    @classmethod
-    def setup_class(cls):
-        if SDL_Init(SDL_INIT_VIDEO) != 0:
-            raise pytest.skip('Video subsystem not supported')
-
-    @classmethod
-    def teardown_class(cls):
-        SDL_Quit()
-
-    @pytest.mark.skip("not implemented")
-    def test_FPSManager(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
     def test_SDL_initFramerate(self):
-        pass
+        manager = sdlgfx.FPSManager()
+        sdlgfx.SDL_initFramerate(manager)
+        assert manager.framecount == 0
+        assert manager.rate == sdlgfx.FPS_DEFAULT
 
-    @pytest.mark.skip("not implemented")
-    def test_SDL_getFramerate(self):
-        pass
+    def test_SDL_getsetFramerate(self):
+        manager = sdlgfx.FPSManager()
+        sdlgfx.SDL_initFramerate(manager)
+        ret = sdlgfx.SDL_setFramerate(manager, 24)
+        fps = sdlgfx.SDL_getFramerate(manager)
+        assert ret == 0
+        assert manager.rate == 24
+        assert fps == 24
 
-    @pytest.mark.skip("not implemented")
-    def test_SDL_setFramerate(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
     def test_SDL_getFramecount(self):
-        pass
+        manager = sdlgfx.FPSManager()
+        sdlgfx.SDL_initFramerate(manager)
+        assert sdlgfx.SDL_getFramecount(manager) == 0
+        sdlgfx.SDL_framerateDelay(manager)
+        assert sdlgfx.SDL_getFramecount(manager) == 1
 
-    @pytest.mark.skip("not implemented")
     def test_SDL_framerateDelay(self):
+        manager = sdlgfx.FPSManager()
+        sdlgfx.SDL_initFramerate(manager)
+        ret = sdlgfx.SDL_setFramerate(manager, 100)
+        assert ret == 0
+        sdlgfx.SDL_framerateDelay(manager)
+        assert manager.framecount == 1
+        frametimes = []
+        for i in range(10):
+            msec_since_last = sdlgfx.SDL_framerateDelay(manager)
+            frametimes.append(msec_since_last)
+        assert round(sum(frametimes) / 10) == 10
+        assert manager.framecount == 11
+
+
+class TestDrawing(object):
+    __tags__ = ["sdl", "sdlgfx"]
+
+    def test_pixel(self, software_renderer):
+        renderer, sf = software_renderer
+        ret = sdlgfx.pixelColor(renderer, 5, 5, RED_U32)
+        assert ret == 0
+        ret = sdlgfx.pixelRGBA(renderer, 5, 5, 255, 255, 255, 255)
+        assert ret == 0
+
+    @pytest.mark.skip("not implemented")
+    def test_hline(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_pixelColor(self):
+    def test_vline(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_pixelRGBA(self):
+    def test_rectangle(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_hlineColor(self):
+    def test_roundedRectangle(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_hlineRGBA(self):
+    def test_box(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_vlineColor(self):
+    def test_roundedBox(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_vlineRGBA(self):
+    def test_line(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_rectangleColor(self):
+    def test_aaline(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_rectangleRGBA(self):
+    def test_thickLine(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_roundedRectangleColor(self):
+    def test_circle(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_roundedRectangleRGBA(self):
+    def test_arc(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_boxColor(self):
+    def test_aacircle(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_boxRGBA(self):
+    def test_filledCircle(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_roundedBoxColor(self):
+    def test_ellipse(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_roundedBoxRGBA(self):
+    def test_aaellipse(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_lineColor(self):
+    def test_filledEllipse(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_lineRGBA(self):
+    def test_pie(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_aalineColor(self):
+    def test_filledPie(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_aalineRGBA(self):
+    def test_trigon(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_thickLineColor(self):
+    def test_aatrigon(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_thickLineRGBA(self):
+    def test_filledTrigon(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_circleColor(self):
+    def test_polygon(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_circleRGBA(self):
+    def test_aapolygon(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_arcColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_arcRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_aacircleColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_aacircleRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledCircleColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledCircleRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_ellipseColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_ellipseRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_aaellipseColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_aaellipseRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledEllipseColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledEllipseRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_pieColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_pieRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledPieColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledPieRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_trigonColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_trigonRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_aatrigonColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_aatrigonRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledTrigonColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledTrigonRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_polygonColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_polygonRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_aapolygonColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_aapolygonRGBA(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledPolygonColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_filledPolygonRGBA(self):
+    def test_filledPolygon(self):
         pass
 
     @pytest.mark.skip("not implemented")
@@ -248,11 +194,7 @@ class TestSDLGFX(object):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_bezierColor(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_bezierRGBA(self):
+    def test_bezier(self):
         pass
 
     @pytest.mark.skip("not implemented")
@@ -264,58 +206,57 @@ class TestSDLGFX(object):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_characterColor(self):
+    def test_character(self):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_characterRGBA(self):
+    def test_string(self):
+        pass
+
+
+class TestRotoZoom(object):
+    __tags__ = ["sdl", "sdlgfx"]
+
+    @pytest.mark.skip("not implemented")
+    def test_rotozoomSurface(self, test_surf):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_stringColor(self):
+    def test_rotozoomSurfaceXY(self, test_surf):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_stringRGBA(self):
+    def test_rotozoomSurfaceSize(self, test_surf):
         pass
 
     @pytest.mark.skip("not implemented")
-    def test_rotozoomSurface(self):
+    def test_rotozoomSurfaceSizeXY(self, test_surf):
         pass
 
-    @pytest.mark.skip("not implemented")
-    def test_rotozoomSurfaceXY(self):
-        pass
+    def test_zoomSurface(self, test_surf):
+        zoom_sf = sdlgfx.zoomSurface(test_surf, 1.5, 2.0, 0)
+        assert isinstance(zoom_sf.contents, surface.SDL_Surface)
+        assert zoom_sf.contents.w == test_surf.contents.w * 1.5
+        assert zoom_sf.contents.h == test_surf.contents.h * 2.0
+        surface.SDL_FreeSurface(zoom_sf)
 
-    @pytest.mark.skip("not implemented")
-    def test_rotozoomSurfaceSize(self):
-        pass
+    def test_zoomSurfaceSize(self, test_surf):
+        out_w, out_h = (c_int(0), c_int(0))
+        w, h = (test_surf.contents.w, test_surf.contents.h)
+        sdlgfx.zoomSurfaceSize(w, h, 1.5, 2.0, byref(out_w), byref(out_h))
+        assert out_w.value == w * 1.5
+        assert out_h.value == h * 2.0
 
-    @pytest.mark.skip("not implemented")
-    def test_rotozoomSurfaceSizeXY(self):
-        pass
+    def test_shrinkSurface(self, test_surf):
+        shrunk_sf = sdlgfx.shrinkSurface(test_surf, 3, 2)
+        assert isinstance(shrunk_sf.contents, surface.SDL_Surface)
+        assert shrunk_sf.contents.w == test_surf.contents.w / 3
+        assert shrunk_sf.contents.h == test_surf.contents.h / 2
+        surface.SDL_FreeSurface(shrunk_sf)
 
-    @pytest.mark.skip("not implemented")
-    def test_zoomSurface(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_zoomSurfaceSize(self):
-        pass
-
-    @pytest.mark.skip("not implemented")
-    def test_shrinkSurface(self):
-        pass
-
-    def test_rotateSurface90Degrees(self):
-        w, h = 470, 530
-        sf = surface.SDL_CreateRGBSurface(0, w, h, 32, 0, 0, 0, 0)
-        assert isinstance(sf.contents, surface.SDL_Surface)
-
-        rotsf = sdlgfx.rotateSurface90Degrees(sf, 1)
+    def test_rotateSurface90Degrees(self, test_surf):
+        rotsf = sdlgfx.rotateSurface90Degrees(test_surf, 1)
         assert isinstance(rotsf.contents, surface.SDL_Surface)
-        assert rotsf.contents.w == h
-        assert rotsf.contents.h == w
-
+        assert rotsf.contents.w == test_surf.contents.h
+        assert rotsf.contents.h == test_surf.contents.w
         surface.SDL_FreeSurface(rotsf)
-        surface.SDL_FreeSurface(sf)

--- a/sdl2/test/sdlgfx_test.py
+++ b/sdl2/test/sdlgfx_test.py
@@ -9,6 +9,11 @@ from sdl2 import surface, render
 sdlgfx = pytest.importorskip("sdl2.sdlgfx")
 
 
+# Framerate test doesn't work right on Github Actions macOS CI
+is_ci_runner = "PYSDL2_DLL_VERSION" in os.environ
+is_macos = sys.platform == "darwin"
+
+
 @pytest.fixture(scope="module")
 def with_sdl():
     if SDL_Init(SDL_INIT_VIDEO) != 0:
@@ -68,6 +73,7 @@ class TestFramerate(object):
         sdlgfx.SDL_framerateDelay(manager)
         assert sdlgfx.SDL_getFramecount(manager) == 1
 
+    @pytest.skipif(is_macos and is_ci_runner, reason="GHA macOS CI has wonky times")
     def test_SDL_framerateDelay(self):
         manager = sdlgfx.FPSManager()
         sdlgfx.SDL_initFramerate(manager)

--- a/sdl2/test/sdlimage_test.py
+++ b/sdl2/test/sdlimage_test.py
@@ -80,6 +80,12 @@ def test_IMG_Init():
     assert len(supported) == len(libs.keys())
 
 
+def _get_image_path(fmt):
+    fname = "surfacetest.{0}".format(fmt)
+    testdir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(testdir, "resources", fname)
+
+
 class TestSDLImage(object):
     __tags__ = ["sdl", "sdlimage"]
 
@@ -97,24 +103,23 @@ class TestSDLImage(object):
         sdlimage.IMG_Quit()
         SDL_Quit()
 
+    def setup_method(self):
+        sdl2.SDL_ClearError()
+
     def test_IMG_Load(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            sf = sdlimage.IMG_Load(filename.encode("utf-8"))
+            fpath = _get_image_path(fmt)
+            sf = sdlimage.IMG_Load(fpath.encode("utf-8"))
             assert isinstance(sf.contents, surface.SDL_Surface)
             surface.SDL_FreeSurface(sf)
 
     def test_IMG_Load_RW(self):
         skip = ['tga'] # TGA broken for Load_RW
-        fname = "surfacetest.%s"
         for fmt in formats:
             if fmt in skip:
                 continue
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 sf = sdlimage.IMG_Load_RW(rwops.rw_from_object(fp), False)
             assert isinstance(sf.contents, surface.SDL_Surface)
             surface.SDL_FreeSurface(sf)
@@ -123,30 +128,13 @@ class TestSDLImage(object):
         sf = surface.SDL_CreateRGBSurface(0, 10, 10, 32, 0, 0, 0, 0)
         rd = render.SDL_CreateSoftwareRenderer(sf)
         skip = []
-        fname = "surfacetest.%s"
         for fmt in formats:
             if fmt in skip:
                 continue
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            tex = sdlimage.IMG_LoadTexture(rd, filename.encode("utf-8"))
+            fpath = _get_image_path(fmt)
+            tex = sdlimage.IMG_LoadTexture(rd, fpath.encode("utf-8"))
             assert isinstance(tex.contents, render.SDL_Texture)
             render.SDL_DestroyTexture(tex)
-
-        #self.assertRaises(sdl.SDLError, sdlimage.load_texture, rd,
-        #                  RESOURCES.get_path("rwopstest.txt"))
-
-        #self.assertRaises(sdl.SDLError, sdlimage.load_texture, rd, None)
-        #self.assertRaises(sdl.SDLError, sdlimage.load_texture, rd, 1234)
-        #self.assertRaises((AttributeError, TypeError),
-        #                  sdlimage.load_texture, None,
-        #                  RESOURCES.get_path("surfacetest.bmp"))
-        #self.assertRaises((AttributeError, TypeError),
-        #                  sdlimage.load_texture, "Test",
-        #                  RESOURCES.get_path("surfacetest.bmp"))
-        #self.assertRaises((AttributeError, TypeError),
-        #                  sdlimage.load_texture, 1234,
-        #                  RESOURCES.get_path("surfacetest.bmp"))
 
         render.SDL_DestroyRenderer(rd)
         surface.SDL_FreeSurface(sf)
@@ -155,13 +143,11 @@ class TestSDLImage(object):
         sf = surface.SDL_CreateRGBSurface(0, 10, 10, 32, 0, 0, 0, 0)
         rd = render.SDL_CreateSoftwareRenderer(sf)
         skip = ['svg', 'tga'] # TGA & SVG broken for LoadTexture_RW
-        fname = "surfacetest.%s"
         for fmt in formats:
             if fmt in skip:
                 continue
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 tex = sdlimage.IMG_LoadTexture_RW(rd, rwops.rw_from_object(fp), 0)
                 assert tex is not None
                 assert isinstance(tex.contents, render.SDL_Texture)
@@ -174,13 +160,11 @@ class TestSDLImage(object):
         sf = surface.SDL_CreateRGBSurface(0, 10, 10, 32, 0, 0, 0, 0)
         rd = render.SDL_CreateSoftwareRenderer(sf)
         skip = ['svg'] # SVG broken for LoadTextureTyped_RW
-        fname = "surfacetest.%s"
         for fmt in formats:
             if fmt in skip:
                 continue
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 rw = rwops.rw_from_object(fp)
                 fmtx = fmt.upper().encode("utf-8")
                 tex = sdlimage.IMG_LoadTextureTyped_RW(rd, rw, 0, fmtx)
@@ -192,85 +176,75 @@ class TestSDLImage(object):
 
     def test_IMG_LoadTyped_RW(self):
         skip = []
-        fname = "surfacetest.%s"
         for fmt in formats:
             if fmt in skip:
                 continue
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
-                sf = sdlimage.IMG_LoadTyped_RW(rwops.rw_from_object(fp), False,
-                                            fmt.upper().encode("utf-8"))
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
+                sf = sdlimage.IMG_LoadTyped_RW(
+                    rwops.rw_from_object(fp), False, fmt.upper().encode("utf-8")
+                )
                 assert isinstance(sf.contents, surface.SDL_Surface)
                 surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadBMP_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.bmp"), "rb")
+        fp = open(_get_image_path("bmp"), "rb")
         sf = sdlimage.IMG_LoadBMP_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadCUR_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.cur"), "rb")
+        fp = open(_get_image_path("cur"), "rb")
         sf = sdlimage.IMG_LoadCUR_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadGIF_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.gif"), "rb")
+        fp = open(_get_image_path("gif"), "rb")
         sf = sdlimage.IMG_LoadGIF_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadICO_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.ico"), "rb")
+        fp = open(_get_image_path("ico"), "rb")
         sf = sdlimage.IMG_LoadICO_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadJPG_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.jpg"), "rb")
+        fp = open(_get_image_path("jpg"), "rb")
         sf = sdlimage.IMG_LoadJPG_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadLBM_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.lbm"), "rb")
+        fp = open(_get_image_path("lbm"), "rb")
         sf = sdlimage.IMG_LoadLBM_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadPCX_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.pcx"), "rb")
+        fp = open(_get_image_path("pcx"), "rb")
         sf = sdlimage.IMG_LoadPCX_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadPNG_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.png"), "rb")
+        fp = open(_get_image_path("png"), "rb")
         sf = sdlimage.IMG_LoadPNG_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadPNM_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.pnm"), "rb")
+        fp = open(_get_image_path("pnm"), "rb")
         sf = sdlimage.IMG_LoadPNM_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
@@ -278,24 +252,21 @@ class TestSDLImage(object):
 
     @pytest.mark.skipif(sdlimage.dll.version < 2002, reason="Added in 2.0.2")
     def test_IMG_LoadSVG_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.svg"), "rb")
+        fp = open(_get_image_path("svg"), "rb")
         sf = sdlimage.IMG_LoadSVG_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadTGA_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.tga"), "rb")
+        fp = open(_get_image_path("tga"), "rb")
         sf = sdlimage.IMG_LoadTGA_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadTIF_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.tif"), "rb")
+        fp = open(_get_image_path("tif"), "rb")
         sf = sdlimage.IMG_LoadTIF_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
@@ -303,8 +274,7 @@ class TestSDLImage(object):
 
     @pytest.mark.xfail(bad_webp, reason="WEBP broken in 2.0.2 binaries for 32-bit Windows")
     def test_IMG_LoadWEBP_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.webp"), "rb")
+        fp = open(_get_image_path("webp"), "rb")
         sf = sdlimage.IMG_LoadWEBP_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
@@ -312,16 +282,14 @@ class TestSDLImage(object):
 
     @pytest.mark.xfail(is32bit or ismacos, reason="XCF currently broken on 32-bit and macOS")
     def test_IMG_LoadXCF_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.xcf"), "rb")
+        fp = open(_get_image_path("xcf"), "rb")
         sf = sdlimage.IMG_LoadXCF_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_LoadXPM_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.xpm"), "rb")
+        fp = open(_get_image_path("xpm"), "rb")
         sf = sdlimage.IMG_LoadXPM_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
@@ -329,19 +297,16 @@ class TestSDLImage(object):
 
     @pytest.mark.skip("not implemented")
     def test_IMG_LoadXV_RW(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.xv"), "rb")
+        fp = open(_get_image_path("xv"), "rb")
         sf = sdlimage.IMG_LoadXV_RW(rwops.rw_from_object(fp))
         fp.close()
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
     def test_IMG_isBMP(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "bmp":
                     assert sdlimage.IMG_isBMP(imgrw)
@@ -349,11 +314,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isBMP(imgrw)
 
     def test_IMG_isCUR(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "cur":
                     assert sdlimage.IMG_isCUR(imgrw)
@@ -361,11 +324,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isCUR(imgrw)
 
     def test_IMG_isGIF(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "gif":
                     assert sdlimage.IMG_isGIF(imgrw)
@@ -373,11 +334,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isGIF(imgrw)
 
     def test_IMG_isICO(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "ico":
                     assert sdlimage.IMG_isICO(imgrw)
@@ -385,11 +344,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isICO(imgrw)
 
     def test_IMG_isJPG(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "jpg":
                     assert sdlimage.IMG_isJPG(imgrw)
@@ -397,11 +354,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isJPG(imgrw)
 
     def test_IMG_isLBM(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "lbm":
                     assert sdlimage.IMG_isLBM(imgrw)
@@ -409,11 +364,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isLBM(imgrw)
 
     def test_IMG_isPCX(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "pcx":
                     assert sdlimage.IMG_isPCX(imgrw)
@@ -421,11 +374,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isPCX(imgrw)
 
     def test_IMG_isPNG(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "png":
                     assert sdlimage.IMG_isPNG(imgrw)
@@ -433,11 +384,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isPNG(imgrw)
 
     def test_IMG_isPNM(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt in ("pnm", "pbm", "ppm", "pgm"):
                     assert sdlimage.IMG_isPNM(imgrw)
@@ -446,11 +395,9 @@ class TestSDLImage(object):
 
     @pytest.mark.skipif(sdlimage.dll.version < 2002, reason="Added in 2.0.2")
     def test_IMG_isSVG(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "svg":
                     assert sdlimage.IMG_isSVG(imgrw)
@@ -458,11 +405,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isSVG(imgrw)
 
     def test_IMG_isTIF(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "tif":
                     assert sdlimage.IMG_isTIF(imgrw)
@@ -470,11 +415,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isTIF(imgrw)
 
     def test_IMG_isWEBP(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "webp":
                     assert sdlimage.IMG_isWEBP(imgrw)
@@ -483,11 +426,9 @@ class TestSDLImage(object):
 
     @pytest.mark.xfail(ismacos, reason="XCF currently broken on macOS")
     def test_IMG_isXCF(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "xcf":
                     assert sdlimage.IMG_isXCF(imgrw)
@@ -495,11 +436,9 @@ class TestSDLImage(object):
                     assert not sdlimage.IMG_isXCF(imgrw)
 
     def test_IMG_isXPM(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "xpm":
                     assert sdlimage.IMG_isXPM(imgrw)
@@ -508,11 +447,9 @@ class TestSDLImage(object):
 
     @pytest.mark.skip("not implemented")
     def test_IMG_isXV(self):
-        fname = "surfacetest.%s"
         for fmt in formats:
-            testdir = os.path.dirname(os.path.abspath(__file__))
-            filename = os.path.join(testdir, "resources", fname % fmt)
-            with open(filename, "rb") as fp:
+            fpath = _get_image_path(fmt)
+            with open(fpath, "rb") as fp:
                 imgrw = rwops.rw_from_object(fp)
                 if fmt == "xv":
                     assert sdlimage.IMG_isXV(imgrw)
@@ -522,8 +459,7 @@ class TestSDLImage(object):
     @pytest.mark.skipif(hasattr(sys, "pypy_version_info"),
         reason="PyPy's ctypes fails to pass a correct string array")
     def test_IMG_ReadXPMFromArray(self):
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        fp = open(os.path.join(testdir, "resources", "surfacetest.xpm"), "rb")
+        fp = open(_get_image_path("xpm"), "rb")
         xpm = b""
         fp.readline()  # /* XPM */
         fp.readline()  # static char * surfacetest_xpm[] = {
@@ -539,18 +475,72 @@ class TestSDLImage(object):
         assert isinstance(sf.contents, surface.SDL_Surface)
         surface.SDL_FreeSurface(sf)
 
-    @pytest.mark.skip("not implemented")
-    def test_IMG_SavePNG(self):
-        pass
+    def test_IMG_SavePNG(self, tmpdir):
+        # Open a PNG that we can re-save
+        fpath = _get_image_path("png")
+        sf = sdlimage.IMG_Load(fpath.encode("utf-8"))
+        assert isinstance(sf.contents, surface.SDL_Surface)
 
-    @pytest.mark.skip("not implemented")
+        # Try saving the PNG to a new folder
+        outpath = os.path.join(str(tmpdir), "save_test.png")
+        ret = sdlimage.IMG_SavePNG(sf, outpath.encode("utf-8"))
+        assert sdl2.SDL_GetError() == b""
+        assert ret == 0
+        assert os.path.exists(outpath)
+        surface.SDL_FreeSurface(sf)
+
     def test_IMG_SavePNG_RW(self):
-        pass
+        # Open a PNG that we can re-save
+        fpath = _get_image_path("png")
+        sf = sdlimage.IMG_Load(fpath.encode("utf-8"))
+        assert isinstance(sf.contents, surface.SDL_Surface)
 
-    @pytest.mark.skip("not implemented")
-    def test_IMG_SaveJPG(self):
-        pass
+        # Try saving the PNG to a new folder
+        outpath = os.path.join(str(tmpdir), "save_test.png")
+        rw = rwops.SDL_RWFromFile(outpath.encode("utf-8"), b"wb")
+        ret = sdlimage.IMG_SavePNG_RW(sf, rw, 0)
+        assert sdl2.SDL_GetError() == b""
+        assert ret == 0
+        assert os.path.exists(outpath)
 
-    @pytest.mark.skip("not implemented")
+        # Try reopening the RW as a PNG
+        sf2 = sdlimage.IMG_LoadPNG_RW(rw)
+        assert sdl2.SDL_GetError() == b""
+        assert isinstance(sf2.contents, surface.SDL_Surface)
+        surface.SDL_FreeSurface(sf)
+        surface.SDL_FreeSurface(sf2)
+
+    def test_IMG_SaveJPG(self, tmpdir):
+        # Open a PNG that we can save to JPG
+        fpath = _get_image_path("png")
+        sf = sdlimage.IMG_Load(fpath.encode("utf-8"))
+        assert isinstance(sf.contents, surface.SDL_Surface)
+
+        # Try saving as JPG to a new folder
+        outpath = os.path.join(str(tmpdir), "save_test.jpg")
+        ret = sdlimage.IMG_SaveJPG(sf, outpath.encode("utf-8"), 90)
+        assert sdl2.SDL_GetError() == b""
+        assert ret == 0
+        assert os.path.exists(outpath)
+        surface.SDL_FreeSurface(sf)
+
     def test_IMG_SaveJPG_RW(self):
-        pass
+        # Open a PNG that we can save to JPG
+        fpath = _get_image_path("png")
+        sf = sdlimage.IMG_Load(fpath.encode("utf-8"))
+        assert isinstance(sf.contents, surface.SDL_Surface)
+
+        # Try saving as JPG to a new folder
+        outpath = os.path.join(str(tmpdir), "save_test.jpg")
+        rw = rwops.SDL_RWFromFile(outpath.encode("utf-8"), b"wb")
+        ret = sdlimage.IMG_SaveJPG_RW(sf, rw, 0, 90)
+        assert sdl2.SDL_GetError() == b""
+        assert ret == 0
+        assert os.path.exists(outpath)
+
+        # Try reopening the RW as a JPG
+        sf2 = sdlimage.IMG_LoadJPG_RW(rw)
+        assert sdl2.SDL_GetError() == b""
+        assert isinstance(sf2.contents, surface.SDL_Surface)
+        surface.SDL_FreeSurface(sf)
+        surface.SDL_FreeSurface(sf2)

--- a/sdl2/test/sdlimage_test.py
+++ b/sdl2/test/sdlimage_test.py
@@ -489,7 +489,7 @@ class TestSDLImage(object):
         assert os.path.exists(outpath)
         surface.SDL_FreeSurface(sf)
 
-    def test_IMG_SavePNG_RW(self):
+    def test_IMG_SavePNG_RW(self, tmpdir):
         # Open a PNG that we can re-save
         fpath = _get_image_path("png")
         sf = sdlimage.IMG_Load(fpath.encode("utf-8"))
@@ -524,7 +524,7 @@ class TestSDLImage(object):
         assert os.path.exists(outpath)
         surface.SDL_FreeSurface(sf)
 
-    def test_IMG_SaveJPG_RW(self):
+    def test_IMG_SaveJPG_RW(self, tmpdir):
         # Open a PNG that we can save to JPG
         fpath = _get_image_path("png")
         sf = sdlimage.IMG_Load(fpath.encode("utf-8"))

--- a/sdl2/test/sdlimage_test.py
+++ b/sdl2/test/sdlimage_test.py
@@ -489,6 +489,7 @@ class TestSDLImage(object):
         assert os.path.exists(outpath)
         surface.SDL_FreeSurface(sf)
 
+    @pytest.mark.skip("not working yet")
     def test_IMG_SavePNG_RW(self, tmpdir):
         # Open a PNG that we can re-save
         fpath = _get_image_path("png")
@@ -524,6 +525,7 @@ class TestSDLImage(object):
         assert os.path.exists(outpath)
         surface.SDL_FreeSurface(sf)
 
+    @pytest.mark.skip("not working yet")
     def test_IMG_SaveJPG_RW(self, tmpdir):
         # Open a PNG that we can save to JPG
         fpath = _get_image_path("png")

--- a/sdl2/test/sdlimage_test.py
+++ b/sdl2/test/sdlimage_test.py
@@ -47,6 +47,9 @@ bad_webp = is32bit and sdlimage.dll.version == 2002
 if bad_webp:
     formats.remove("webp")
 
+# JPG saving requires SDL2_image >= 2.0.2 and isn't in official mac binaries
+no_jpeg_save = sdlimage.dll.version < 2002 or ismacos
+
 
 def test_IMG_Linked_Version():
     v = sdlimage.IMG_Linked_Version()
@@ -511,6 +514,7 @@ class TestSDLImage(object):
         surface.SDL_FreeSurface(sf)
         surface.SDL_FreeSurface(sf2)
 
+    @pytest.mark.skipif(no_jpeg_save, reason="Added in 2.0.2, not in macOS bnaries")
     def test_IMG_SaveJPG(self, tmpdir):
         # Open a PNG that we can save to JPG
         fpath = _get_image_path("png")
@@ -526,6 +530,7 @@ class TestSDLImage(object):
         surface.SDL_FreeSurface(sf)
 
     @pytest.mark.skip("not working yet")
+    @pytest.mark.skipif(no_jpeg_save, reason="Added in 2.0.2, not in macOS bnaries")
     def test_IMG_SaveJPG_RW(self, tmpdir):
         # Open a PNG that we can save to JPG
         fpath = _get_image_path("png")


### PR DESCRIPTION
<!--Thanks for contributing to PySDL2!-->

# PR Description

This PR updates the Python bindings for the SDL2 add-on modules (TTF, Mixer, Image, and GFX) to use standard Python function definitions, allowing for keyword arguments, Sphinx autodoc support, better flexibility in terms of error handling, and more.

This PR also includes updates to the unit tests to more thoroughly test the add-on libraries to make sure this PR doesn't break anything.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
