### PR TITLE
Rewrite and redocument the sdl2.ext.image API

### DIFF
--- a/doc/modules/ext/image.rst
+++ b/doc/modules/ext/image.rst
@@ -1,27 +1,22 @@
 .. currentmodule:: sdl2.ext
 
-Image loaders
-=============
+`sdl2.ext.image` - Importing and Exporting Image Files
+======================================================
 
-.. function:: get_image_formats() -> (str, str, ...)
+The :mod:`sdl2.ext.image` module provides some simple functions for importing
+images as SDL surfaces and exporting SDL surfaces to image files.
 
-   Gets the formats supported by PySDL2 in the default installation.
+The basic functions :func:`load_bmp` and :func:`save_bmp` load and save BMP
+files, and are guaranteed to be available on all systems supported by PySDL2.
+The :func:`load_img` function can be used to import additional image formats
+(e.g. JPEG, PNG), but requires that the **SDL_image** library is installed on
+the target system (can be installed as a Python dependency with ``pysdl2-dll``
+on platforms that support it).
 
-.. function:: load_image(fname : str[, enforce=None]) -> sdl2.SDL_Surface
+In addition to importing images from files, this module also provides the
+:func:`pillow_to_surface` function for converting :obj:`Image` objects from the
+`Pillow <https://pillow.readthedocs.io/en/stable/>`_ Python library to SDL
+surfaces.
 
-   Creates a :class:`sdl2.SDL_Surface` from an image file.
-
-   This function makes use of the `Python Imaging Library
-   <http://www.pythonware.com/products/pil/>`_, if it is available on the
-   target execution environment. The function will try to load the file via
-   :mod:`sdl2` first. If the file could not be loaded, it will try to load it
-   via :mod:`sdl2.sdlimage` and PIL.
-
-   You can force the function to use only one of them, by passing the
-   *enforce* as either ``"PIL"`` or ``"SDL"``.
-
-   .. note::
-
-      This will call :func:`sdl2.sdlimage.IMG_Init()` implicitly with the
-      default arguments, if the module is available and if
-      :func:`sdl2.SDL_LoadBMP()` failed to load the image.
+.. automodule:: sdl2.ext.image
+   :members:

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -33,6 +33,15 @@ New Features:
   :mod:`sdl2.ext.resources` submodule (PR #204)
 * Added a new function :func:`sdl2.ext.surface_to_ndarray` that returns a
   non-transposed copy of a given SDL surface as a 2D or 3D Numpy array (PR #204)
+* Added new functions :func:`sdl2.ext.load_bmp` and :func:`sdl2.ext.load_img`
+  for importing image files using SDL2 and SDL_image, respectively. Both new
+  functions automatically convert the obtained surfaces to the ARGB8888 pixel
+  format by default (PR #205)
+* Added a new function :func:`sdl2.ext.save_bmp` for saving SDL surfaces to
+  BMP files (PR #205)
+* Added a new function :func:`sdl2.ext.pillow_to_surface` for converting
+  :obj:`PIL.Image.Image` objects from the Pillow library to SDL
+  surfaces (PR #205)
 
 Fixed Bugs:
 
@@ -65,6 +74,13 @@ API Changes:
 Deprecation Notices:
 
 * The :func:`sdl2.ext.open_url` function has been deprecated (PR #204)
+* The :func:`sdl2.ext.load_image` function has been deprecated, as it
+  unexpectedly produces different surface formats depending on the backend used.
+  New projects should use the new :func:`sdl2.ext.load_img`,
+  :func:`sdl2.ext.load_bmp`, and/or :func:`sdl2.ext.pillow_to_surface` functions
+  instead (PR #205)
+* The :func:`sdl2.ext.get_image_formats` function has been deprecated, as it
+  gives inaccurate results in most cases (PR #205)
 
 
 0.9.9

--- a/sdl2/ext/image.py
+++ b/sdl2/ext/image.py
@@ -1,7 +1,9 @@
-"""Image loaders."""
-from .common import SDLError
-from .compat import UnsupportedError, byteify
-from .. import endian, surface, pixels
+import os
+from .. import endian, surface, pixels, error
+from .common import raise_sdl_err
+from .compat import UnsupportedError, byteify, stringify
+from .resources import _validate_path
+from .surface import _get_target_surface
 
 _HASPIL = True
 try:
@@ -15,145 +17,312 @@ try:
 except ImportError:
     _HASSDLIMAGE = False
 
-__all__ = ["get_image_formats", "load_image"]
+__all__ = [
+    "get_image_formats", "load_bmp", "load_img", "save_bmp",
+    "pillow_to_surface", "load_image"
+]
+
+
+_SDL_IMAGE_FLAGS = -1
+
+
+def _sdl_image_init():
+    global _SDL_IMAGE_FLAGS
+    if _SDL_IMAGE_FLAGS == -1:
+        _SDL_IMAGE_FLAGS = sdlimage.IMG_Init(
+            sdlimage.IMG_INIT_JPG | sdlimage.IMG_INIT_PNG |
+            sdlimage.IMG_INIT_TIF | sdlimage.IMG_INIT_WEBP
+        )
+    return _SDL_IMAGE_FLAGS
+
+
+def _get_mode_properties(mode):
+    le = endian.SDL_BYTEORDER == endian.SDL_LIL_ENDIAN
+    rmask, gmask, bmask, amask = (0, 0, 0, 0)
+    if mode in ("1", "L", "P"):
+        # "1" = B/W, 1 bit per byte
+        # "L" = greyscale, 8-bit
+        # "P" = palette-based, 8-bit
+        depth = 8
+    elif mode == "RGB":
+        # RGB: 3x8-bit, 24bpp
+        depth = 24
+        rmask = 0x0000FF if le else 0xFF0000
+        gmask = 0x00FF00
+        bmask = 0xFF0000 if le else 0x0000FF
+    elif mode in ("RGBA", "RGBX"):
+        # RGBX: 4x8-bit, no alpha
+        # RGBA: 4x8-bit, alpha
+        depth = 32
+        rmask = 0x000000FF if le else 0xFF000000
+        gmask = 0x0000FF00 if le else 0x00FF0000
+        bmask = 0x00FF0000 if le else 0x0000FF00
+        if mode == "RGBA":
+            amask = 0xFF000000 if le else 0x000000FF
+    else:
+        raise TypeError("Cannot convert {0} data to surface.".format(mode))
+    return (rmask, gmask, bmask, amask, depth)
 
 
 def get_image_formats():
-    """Gets the formats supported in the default installation."""
+    # This function is deprecated and gives inaccurate results
     if not _HASPIL and not _HASSDLIMAGE:
         return ("bmp", )
     return ("bmp", "cur", "gif", "ico", "jpg", "lbm", "pbm", "pcx", "pgm",
             "png", "pnm", "ppm", "svg", "tga", "tif", "webp", "xcf", "xpm")
 
 
+def load_bmp(path):
+    """Imports a BMP (bitmap image) file as an SDL surface.
+
+    Because BMP importing and exporting is part of the core SDL2 library,
+    this function is guaranteed to be available on all platforms and
+    installations that support PySDL2.
+
+    Args:
+        path (str): The relative (or absolute) path to the BMP image to import.
+
+    Returns:
+        :obj:`~sdl2.SDL_Surface`: An SDL surface containing the imported image.
+
+    """
+    fullpath, fname = _validate_path(path, "an image")
+    img_surf = surface.SDL_LoadBMP(byteify(fullpath))
+    if not img_surf:
+        raise_sdl_err("importing '{0}' as a BMP".format(fname))
+
+    return img_surf.contents
+
+
+def save_bmp(source, path, overwrite=False):
+    """Exports an SDL surface to a BMP (bitmap image) file.
+
+    Because BMP importing and exporting is part of the core SDL2 library,
+    this function is guaranteed to be available on all platforms and
+    installations that support PySDL2.
+
+    Args:
+        source (:obj:`~sdl2.SDL_Surface`): The surface to save as a BMP file.
+        path (str): The relative (or absolute) path to which the BMP should be
+            saved.
+        overwrite (bool, optional): Whether the image should be overwritten if
+            a file at that path already exists. Defaults to False.
+
+    """
+    fullpath, fname = _validate_path(path, "", write=True)
+    if os.path.exists(fullpath):
+        if overwrite:
+            os.remove(fullpath)
+        else:
+            e = "A file already exists at the given path: {0}"
+            raise RuntimeError(e.format(fullpath))
+    surf = _get_target_surface(source, argname="source")
+    ret = surface.SDL_SaveBMP(surf, byteify(fullpath))
+    if ret != 0:
+        raise_sdl_err("saving '{0}' as a BMP".format(fname))
+
+
+def load_img(path, as_argb=True):
+    """Imports an image file as an SDL surface using the **SDL_image** library.
+
+    This function supports a wide range of image formats, including GIF, BMP,
+    JPEG, PNG, TIFF, and WebP. For a full list, consult the SDL_image
+    documentation.
+
+    By default, this function also converts the imported surface to 32-bit ARGB
+    format for consistency across functions and better compatibility with SDL2
+    renderers. To disable ARGB conversion, set the ``as_argb`` parameter to
+    ``False``.
+
+    .. note::
+       Because SDL_image is not part of the core SDL2 library, this function
+       will only work on systems where the SDL_image library is installed.
+       Additionally, support for PNG, JPEG, TIFF, and WebP in SDL_image is
+       dynamic and are not guaranteed to be available on all systems.
+
+    Args:
+        path (str): The relative (or absolute) path to the image to import.
+        as_argb (bool, optional): Whether the obtained surface should be
+            converted to 32-bit ARGB pixel format or left as-is. Defaults to
+            ``True`` (convert to ARGB).
+
+    Returns:
+        :obj:`~sdl2.SDL_Surface`: An SDL surface containing the imported image.
+
+    """
+    if not _HASSDLIMAGE:
+        err = "'{0}' requires the SDL_image library, which could not be found."
+        raise RuntimeError(err.format("load_img"))
+
+    # Import the image file using the generic SDL_Image loader
+    fullpath, fname = _validate_path(path, "an image")
+    _sdl_image_init()
+    img_surf = sdlimage.IMG_Load(byteify(fullpath))
+    if not img_surf:
+        raise_sdl_err("importing '{0}' using SDL_image".format(fname))
+
+    # Determine whether to use 32-bit ARGB or original pixel format
+    ARGB32 = pixels.SDL_PIXELFORMAT_ARGB8888
+    out_fmt = img_surf.contents.format
+    if as_argb and out_fmt.contents.format != ARGB32:
+        out_fmt = pixels.SDL_AllocFormat(ARGB32)
+        surfcopy = surface.SDL_ConvertSurface(img_surf, out_fmt, 0)
+        surface.SDL_FreeSurface(img_surf)
+        img_surf = surfcopy
+        if not img_surf:
+            raise_sdl_err("converting '{0}' to ARGB format".format(fname))
+
+    return img_surf.contents
+
+
+def pillow_to_surface(img, as_argb=True):
+    """Converts a :obj:`PIL.Image.Image` object to an SDL surface.
+
+    This function returns a copy of the original object's pixel data, meaning
+    that the original Image can be modified or deleted without affecting the
+    returned surface (and vice versa).
+    
+    By default, this function also converts the surface to 32-bit ARGB format
+    for consistency across functions and better compatibility with SDL2
+    renderers. To disable ARGB conversion, set the ``as_argb`` parameter to
+    ``False``.
+
+    Args:
+        img (:obj:`PIL.Image.Image`): The Image object to convert to an SDL
+            surface.
+        as_argb (bool, optional): Whether the obtained surface should be
+            converted to 32-bit ARGB pixel format or left as-is. Defaults to
+            ``True`` (convert to ARGB).
+    
+    Returns:
+        :obj:`~sdl2.SDL_Surface`: An SDL surface copy of the PIL image.
+
+    """
+    if not (hasattr(img, "mode") and hasattr(img, "size")):
+        raise TypeError("'img' must be a valid PIL Image.")
+
+    # Determine correct properties for new surface from PIL data
+    mode = img.mode
+    width, height = img.size
+    rmask, gmask, bmask, amask, depth = _get_mode_properties(mode)
+    pitch = width * int(depth / 8)
+
+    # Get PIL pixel bytes and cast them to an SDL surface
+    pxbuf = img.tobytes()
+    imgsurface = surface.SDL_CreateRGBSurfaceFrom(
+        pxbuf, width, height, depth, pitch, rmask, gmask, bmask, amask
+    )
+    if not imgsurface:
+        raise_sdl_err("creating a surface from a PIL Image")
+    imgsurface = imgsurface.contents
+
+    # Retrieve the palette for the image (if any)
+    palette = []
+    if mode == "P":
+        palette = img.getpalette()
+    elif mode in ("1", "L"):
+        for i in range(256):
+            palette += [i, i, i]
+
+    if len(palette):
+        # Convert the Pillow palette to an SDL palette
+        num_colors = len(palette) // 3
+        sdlpalette = pixels.SDL_AllocPalette(num_colors)
+        if not sdlpalette:
+            raise_sdl_err("initializing the palette for the SDL surface")
+        for idx in range(num_colors):
+            start, end = (idx * 3, idx * 3 + 3)
+            r, g, b = palette[start:end]
+            sdlpalette.contents.colors[idx] = pixels.SDL_Color(r, g, b)
+        
+        # Apply the converted palette to the surface
+        ret = surface.SDL_SetSurfacePalette(imgsurface, sdlpalette)
+        pixels.SDL_FreePalette(sdlpalette)
+        if ret != 0:
+            raise_sdl_err("converting the palette from the PIL Image")
+
+        # If the image has a single transparent palette index, set that index as
+        # the color key to make blitting correct.
+        k = "transparency"
+        if k in img.info and isinstance(img.info[k], int):
+            surface.SDL_SetColorKey(imgsurface, True, img.info[k])
+
+    # Determine whether to use 32-bit ARGB or original pixel format
+    out_fmt = imgsurface.format
+    if as_argb:
+        out_fmt = pixels.SDL_AllocFormat(pixels.SDL_PIXELFORMAT_ARGB8888)
+
+    # Create a new surface from the converted data for memory safety
+    surfcopy = surface.SDL_ConvertSurface(imgsurface, out_fmt, 0)
+    surface.SDL_FreeSurface(imgsurface)
+    if not surfcopy:
+        raise_sdl_err("copying the PIL Image data to a new surface")
+    
+    return surfcopy.contents
+
+
 def load_image(fname, enforce=None):
-    """Creates a SDL_Surface from an image file.
+    """**[Deprecated]** Imports an image file as an SDL surface.
 
-    This function makes use of the Python Imaging Library, if it is available
-    on the target execution environment. The function will try to load the
-    file via sdl2 first. If the file could not be loaded, it will try
-    to load it via sdl2.sdlimage and PIL.
+    This function uses either the SDL_image library or the Pillow Python package
+    for importing images, using SDL2's built-in BMP loader as a fall-back if
+    neither are available.
 
-    You can force the function to use only one of them, by passing the enforce
-    as either "PIL" or "SDL".
+    .. warning::
+       Due to a long-standing bug, the resulting image surfaces can have
+       different pixel formats depending on which backend was used, making
+       behavior unpredictable across different systems. As such this function
+       is deprecated, and is only maintained to avoid breaking existing code.
+       For new projects, the :func:`load_bmp`, :func:`load_img`, and/or
+       :func:`pillow_to_surface` functions should be used instead.
 
-    Note: This will call sdl2.sdlimage.init() implicitly with the default
-    arguments, if the module is available and if sdl2.SDL_LoadBMP() failed to
-    load the image.
+    Args:
+        fname (str): The relative (or absolute) path to the image to import.
+        enforce (str, optional): A string indicating the specific backend to
+            use for loading images. Can be either "PIL" for Pillow-only, "SDL"
+            for SDL2 and SDL_image only, or ``None`` for no enforced backend.
+            Defaults to ``None``.
+
+    Returns:
+        :obj:`~sdl2.SDL_Surface`: An SDL surface containing the imported image.
+
     """
     if enforce is not None and enforce not in ("PIL", "SDL"):
         raise ValueError("enforce must be either 'PIL' or 'SDL', if set")
-    if fname is None:
+    elif enforce == "PIL" and not _HASPIL:
+        raise UnsupportedError("cannot use PIL (not found)")
+    if fname is None or not hasattr(fname, "upper"):
         raise ValueError("fname must be a string")
 
-    name = fname
-    if hasattr(fname, 'encode'):
-        name = byteify(fname, "utf-8")
-
-    if not _HASPIL and not _HASSDLIMAGE:
-        imgsurface = surface.SDL_LoadBMP(name)
-        if not imgsurface:
-            raise UnsupportedError(load_image,
-                                   "cannot use PIL or SDL for image loading")
-        return imgsurface.contents
-    if enforce == "PIL" and not _HASPIL:
-        raise UnsupportedError(load_image, "cannot use PIL (not found)")
-    if enforce == "SDL" and not _HASSDLIMAGE:
-        imgsurface = surface.SDL_LoadBMP(name)
-        if not imgsurface:
-            raise UnsupportedError(load_image,
-                                   "cannot use SDL_image (not found)")
-        return imgsurface.contents
-
+    name = byteify(fname)
     imgsurface = None
+    err = "Unable to import '{0}'".format(fname)
+
+    # Try importing image as a BMP if other decoders aren't available
+    if (enforce == "SDL" or not _HASPIL) and not _HASSDLIMAGE:
+        imgsurface = surface.SDL_LoadBMP(name)
+        if not imgsurface:
+            error.SDL_ClearError()
+            err += " as a BMP (must have SDL_image or Pillow to support "
+            err += "other formats)"
+            raise RuntimeError(err)
+        else:
+            return imgsurface.contents
+
+    # Try imporing the image using SDL_image
     if enforce != "PIL" and _HASSDLIMAGE:
-        sdlimage.IMG_Init(sdlimage.IMG_INIT_JPG | sdlimage.IMG_INIT_PNG |
-                          sdlimage.IMG_INIT_TIF | sdlimage.IMG_INIT_WEBP)
+        _sdl_image_init()
         imgsurface = sdlimage.IMG_Load(name)
         if not imgsurface:
             # An error occured - if we do not try PIL, break out now
             if not _HASPIL or enforce == "SDL":
-                raise SDLError(sdlimage.IMG_GetError())
+                err += " using SDL_image: " + stringify(error.SDL_GetError())
+                error.SDL_ClearError()
+                raise RuntimeError(err)
         else:
-            imgsurface = imgsurface.contents
+            return imgsurface.contents
 
-    if enforce != "SDL" and _HASPIL and not imgsurface:
+    # Try importing the image using Pillow and converting to an SDL surface
+    if enforce != "SDL" and _HASPIL:
         image = Image.open(fname)
-        mode = image.mode
-        width, height = image.size
-        rmask = gmask = bmask = amask = 0
-        if mode in ("1", "L", "P"):
-            # 1 = B/W, 1 bit per byte
-            # "L" = greyscale, 8-bit
-            # "P" = palette-based, 8-bit
-            pitch = width
-            depth = 8
-        elif mode == "RGB":
-            # 3x8-bit, 24bpp
-            if endian.SDL_BYTEORDER == endian.SDL_LIL_ENDIAN:
-                rmask = 0x0000FF
-                gmask = 0x00FF00
-                bmask = 0xFF0000
-            else:
-                rmask = 0xFF0000
-                gmask = 0x00FF00
-                bmask = 0x0000FF
-            depth = 24
-            pitch = width * 3
-        elif mode in ("RGBA", "RGBX"):
-            # RGBX: 4x8-bit, no alpha
-            # RGBA: 4x8-bit, alpha
-            if endian.SDL_BYTEORDER == endian.SDL_LIL_ENDIAN:
-                rmask = 0x000000FF
-                gmask = 0x0000FF00
-                bmask = 0x00FF0000
-                if mode == "RGBA":
-                    amask = 0xFF000000
-            else:
-                rmask = 0xFF000000
-                gmask = 0x00FF0000
-                bmask = 0x0000FF00
-                if mode == "RGBA":
-                    amask = 0x000000FF
-            depth = 32
-            pitch = width * 4
-        else:
-            # We do not support CMYK or YCbCr for now
-            raise TypeError("unsupported image format")
-
-        pxbuf = image.tobytes()
-        imgsurface = surface.SDL_CreateRGBSurfaceFrom(pxbuf, width, height,
-                                                      depth, pitch, rmask,
-                                                      gmask, bmask, amask)
-        if not imgsurface:
-            raise SDLError()
-        imgsurface = imgsurface.contents
-        # the pixel buffer must not be freed for the lifetime of the surface
-        imgsurface._pxbuf = pxbuf
-
-        if mode == "P":
-            # Create a SDL_Palette for the SDL_Surface
-            def _chunk(seq, size):
-                for x in range(0, len(seq), size):
-                    yield seq[x:x + size]
-
-            rgbcolors = image.getpalette()
-            sdlpalette = pixels.SDL_AllocPalette(len(rgbcolors) // 3)
-            if not sdlpalette:
-                raise SDLError()
-            SDL_Color = pixels.SDL_Color
-            for idx, (r, g, b) in enumerate(_chunk(rgbcolors, 3)):
-                sdlpalette.contents.colors[idx] = SDL_Color(r, g, b)
-            ret = surface.SDL_SetSurfacePalette(imgsurface, sdlpalette)
-            # This will decrease the refcount on the palette, so it gets
-            # freed properly on releasing the SDL_Surface.
-            pixels.SDL_FreePalette(sdlpalette)
-            if ret != 0:
-                raise SDLError()
-
-            # If the image has a single transparent palette index, set
-            # that index as the color key to make blitting correct.
-            if 'transparency' in image.info and isinstance(image.info['transparency'], int):
-                surface.SDL_SetColorKey(imgsurface, True, image.info['transparency'])
-
-    return imgsurface
+        return pillow_to_surface(image, as_argb=False)

--- a/sdl2/test/sdl2ext_image_test.py
+++ b/sdl2/test/sdl2ext_image_test.py
@@ -1,7 +1,11 @@
+import os
 import sys
 import pytest
+import sdl2
 from sdl2 import ext as sdl2ext
-from sdl2 import surface
+from sdl2.ext import color
+from sdl2 import surface as surf
+from sdl2 import pixels
 
 try:
     from sdl2 import sdlimage
@@ -9,45 +13,50 @@ try:
 except:
     _HASSDLIMAGE=False
 
-RESOURCES = sdl2ext.Resources(__file__, "resources")
+try:
+    import PIL
+    _HASPIL = True
+except ImportError:
+    _HASPIL = False
+
+
+parent_path = os.path.abspath(os.path.dirname(__file__))
+resource_path = os.path.join(parent_path, "resources")
 
 is32bit = sys.maxsize <= 2**32
 ismacos = sys.platform == "darwin"
+skip_formats = []
 
-formats = [ # Do not use bmp - it's contained in resources.zip
-           "cur",
-           "gif",
-           "ico",
-           "jpg",
-           "lbm",
-           "pbm",
-           "pcx",
-           "pgm",
-           "png",
-           "pnm",
-           "ppm",
-           "svg",
-           "tga",
-           "tif",
-           "webp",
-           "xcf",
-           "xpm",
-           # "xv",
-           ]
+if _HASSDLIMAGE:
+    # SVG unsupported on SDL2_image < 2.0.2
+    if sdlimage.dll.version < 2002:
+        skip_formats.append("svg")
 
-# SVG unsupported on SDL2_image < 2.0.2
-if _HASSDLIMAGE and sdlimage.dll.version < 2002:
-    formats.remove("svg")
+    # As of SDL2_image 2.0.5, XCF support seems to be broken (fails to load
+    # on 32-bit, transparent surface on 64-bit)
+    # XCF support is also broken in official SDL2_image macOS .frameworks
+    if sdlimage.dll.version == 2005 or ismacos:
+        skip_formats.append("xcf")
 
-# As of SDL2_image 2.0.5, XCF support seems to be broken on 32-bit builds
-# XCF support is also broken in official SDL2_image macOS .frameworks
-if is32bit or ismacos:
-    formats.remove("xcf")
+    # WEBP support is broken in the 32-bit Windows SDL2_image 2.0.2 binary
+    if is32bit and sdlimage.dll.version == 2002:
+        skip_formats.append("webp")
 
-# WEBP support seems to be broken in the 32-bit Windows SDL2_image 2.0.2 binary
-bad_webp = is32bit and sdlimage.dll.version == 2002
-if bad_webp:
-    formats.remove("webp")
+
+# List of lossy/non-color formats that shouldn't be compared against reference
+# during tests
+skip_color_check = ['gif', 'jpg', 'lbm', 'pbm', 'pgm', 'svg', 'webp']
+
+# SDL 2.0.10 has a bug that messes up converting surfaces with transparency
+if sdl2.dll.version == 2010:
+    skip_color_check.append('xpm')
+
+colors = {
+    'red': color.Color(255, 0, 0, 255),
+    'blue': color.Color(0, 0, 255, 255),
+    'black': color.Color(0, 0, 0, 255),
+    'white': color.Color(255, 255, 255, 255)
+}
 
 
 class TestSDL2ExtImage(object):
@@ -64,33 +73,177 @@ class TestSDL2ExtImage(object):
     def teardown_class(cls):
         sdl2ext.quit()
 
-    def test_get_image_formats(self):
-        assert isinstance(sdl2ext.get_image_formats(), tuple)
-        supformats = sdl2ext.get_image_formats()
-        for fmt in formats:
-            assert fmt in supformats
+
+    def check_image_contents(self, img):
+        # Test different coordinates on surface
+        pxview = sdl2ext.PixelView(img)
+        img_red = color.ARGB(pxview[0][0])
+        img_blue = color.ARGB(pxview[0][16])
+        img_white = color.ARGB(pxview[0][31])
+        img_black = color.ARGB(pxview[31][31])
+        assert img_red == colors['red']
+        assert img_blue == colors['blue']
+        assert img_white == colors['white']
+        assert img_black == colors['black']
+
+    def test_load_bmp(self):
+        # Test loading a basic BMP image
+        img_path = os.path.join(resource_path, "surfacetest.bmp")
+        sf = sdl2ext.load_bmp(img_path)
+        assert isinstance(sf, surf.SDL_Surface)
+        self.check_image_contents(sf)
+        surf.SDL_FreeSurface(sf)
+
+        # Test exception on missing file
+        bad_path = os.path.join(resource_path, "doesnt_exist.bmp")
+        with pytest.raises(IOError):
+            sdl2ext.load_bmp(bad_path)
+
+        # Test exception on bad file type
+        bad_type = os.path.join(resource_path, "surfacetest.png")
+        with pytest.raises(sdl2ext.SDLError):
+            sdl2ext.load_bmp(bad_type)
+
+
+    def test_save_bmp(self, tmpdir):
+        # Open a BMP that we can re-save
+        img_path = os.path.join(resource_path, "surfacetest.bmp")
+        sf = sdl2ext.load_bmp(img_path)
+        assert isinstance(sf, surf.SDL_Surface)
+
+        # Try saving the BMP to a new folder and re-loading it
+        outpath = os.path.join(str(tmpdir), "save_test.bmp")
+        sdl2ext.save_bmp(sf, outpath)
+        assert os.path.exists(outpath)
+        sf_saved = sdl2ext.load_bmp(outpath)
+        assert isinstance(sf_saved, surf.SDL_Surface)
+        self.check_image_contents(sf_saved)
+
+        # Try modifying/overwriting the existing BMP
+        sdl2ext.fill(sf, (0, 255, 0, 255))
+        sdl2ext.save_bmp(sf, outpath, overwrite=True)
+        sf_saved2 = sdl2ext.load_bmp(outpath)
+        assert isinstance(sf_saved2, surf.SDL_Surface)
+        with pytest.raises(AssertionError):
+            self.check_image_contents(sf_saved2)
+
+        surf.SDL_FreeSurface(sf)
+        surf.SDL_FreeSurface(sf_saved)
+        surf.SDL_FreeSurface(sf_saved2)
+
+        # Test existing file exception with overwrite=False
+        with pytest.raises(RuntimeError):
+            sdl2ext.save_bmp(sf_saved, outpath, overwrite=False)
+        
+        # Test exception with non-existent save directory
+        bad_path = os.path.join(resource_path, "doesnt_exist", "tst.bmp")
+        with pytest.raises(IOError):
+            sdl2ext.save_bmp(sf_saved, bad_path)
+
+
+    def test_load_img(self):
+        # Test loading all test images, with and without ARGB conversion
+        resources = os.listdir(resource_path)
+        test_imgs = [f for f in resources if f[:11] == "surfacetest"]
+        for img in test_imgs:
+            img_path = os.path.join(resource_path, img)
+            fmt = img.split(".")[-1]
+            if fmt in skip_formats:
+                continue
+
+            sf = sdl2ext.load_img(img_path)
+            assert isinstance(sf, surf.SDL_Surface)
+            assert sf.format.contents.format == pixels.SDL_PIXELFORMAT_ARGB8888
+            if fmt not in skip_color_check:
+                self.check_image_contents(sf)
+            surf.SDL_FreeSurface(sf)
+
+            sf2 = sdl2ext.load_img(img_path, as_argb=False)
+            assert isinstance(sf2, surf.SDL_Surface)
+            surf.SDL_FreeSurface(sf2)
+
+        # Test exception on missing file
+        bad_path = os.path.join(resource_path, "doesnt_exist.bmp")
+        with pytest.raises(IOError):
+            sdl2ext.load_img(bad_path)
+
+        # Test exception on bad file type
+        bad_type = os.path.join(resource_path, "tuffy.ttf")
+        with pytest.raises(sdl2ext.SDLError):
+            sdl2ext.load_img(bad_type)
+
+
+    @pytest.mark.skipif(not _HASPIL, reason="Pillow library is not installed")
+    def test_pillow_to_image(self):
+        # Import an image using Pillow
+        from PIL import Image
+        img_path = os.path.join(resource_path, "surfacetest.bmp")
+        pil_img = Image.open(img_path)
+
+        # Convert the image to an SDL surface and verify it worked
+        sf = sdl2ext.pillow_to_surface(pil_img)
+        assert isinstance(sf, surf.SDL_Surface)
+        self.check_image_contents(sf)
+        surf.SDL_FreeSurface(sf)
+
+        # Try converting a palette image
+        palette_img = pil_img.convert("P", palette=Image.WEB)
+        sfp = sdl2ext.pillow_to_surface(palette_img)
+        pxformat = sfp.format.contents
+        assert isinstance(sfp, surf.SDL_Surface)
+        self.check_image_contents(sfp)
+        assert pxformat.BytesPerPixel == 4
+        surf.SDL_FreeSurface(sfp)
+
+        # Try converting a palette image without ARGB conversion
+        sfp2 = sdl2ext.pillow_to_surface(palette_img, False)
+        pxformat = sfp2.format.contents
+        assert isinstance(sfp2, surf.SDL_Surface)
+        assert pxformat.BytesPerPixel == 1
+        sdl_palette = pxformat.palette.contents
+        pil_palette = palette_img.getpalette()
+        assert sdl_palette.colors[0].r == pil_palette[0]
+        assert sdl_palette.colors[0].g == pil_palette[1]
+        assert sdl_palette.colors[0].b == pil_palette[2]
+        surf.SDL_FreeSurface(sfp2)
+
+        # Test loading all supported test images and compare against reference
+        resources = os.listdir(resource_path)
+        test_imgs = [f for f in resources if f[:11] == "surfacetest"]
+        for img in test_imgs:
+            fmt = img.split(".")[-1]
+            if fmt in ("webp", "xcf", "lbm", "svg"):
+                continue
+            pil_img = Image.open(os.path.join(resource_path, img))
+            sf = sdl2ext.pillow_to_surface(pil_img)
+            assert isinstance(sf, surf.SDL_Surface)
+            assert sf.format.contents.format == pixels.SDL_PIXELFORMAT_ARGB8888
+            if fmt not in skip_color_check:
+                self.check_image_contents(sf)
+            surf.SDL_FreeSurface(sf)
+
 
     def test_load_image(self):
-        # TODO: add image comparision to check, if it actually does the
-        # right thing (SDL2 BMP loaded image?)
-        # Add argument tests
-        try:
-            import PIL
-            _HASPIL = True
-        except ImportError:
-            _HASPIL = False
+        resources = os.listdir(resource_path)
+        test_imgs = [f for f in resources if f[:11] == "surfacetest"]
+        for img in test_imgs:
+            img_path = os.path.join(resource_path, img)
+            fmt = img.split(".")[-1]
+            if fmt in skip_formats:
+                continue
 
-        fname = "surfacetest.%s"
-        for fmt in formats:
-            filename = RESOURCES.get_path(fname % fmt)
-            sf = sdl2ext.load_image(filename)
-            assert isinstance(sf, surface.SDL_Surface)
+            # Try normal loading
+            sf = sdl2ext.load_image(img_path)
+            assert isinstance(sf, surf.SDL_Surface)
 
             # Force only PIL
             if _HASPIL and fmt not in ("webp", "xcf", "lbm", "svg"):
-                sf = sdl2ext.load_image(filename, enforce="PIL")
-                assert isinstance(sf, surface.SDL_Surface)
+                sf = sdl2ext.load_image(img_path, enforce="PIL")
+                assert isinstance(sf, surf.SDL_Surface)
 
             # Force only sdlimage
-            sf = sdl2ext.load_image(filename, enforce="SDL")
-            assert isinstance(sf, surface.SDL_Surface)
+            sf = sdl2ext.load_image(img_path, enforce="SDL")
+            assert isinstance(sf, surf.SDL_Surface)
+
+            # Clean up surface now that we're done with it
+            surf.SDL_FreeSurface(sf)

--- a/sdl2/test/sdl2ext_sprite_test.py
+++ b/sdl2/test/sdl2ext_sprite_test.py
@@ -194,13 +194,10 @@ class TestSDL2ExtSprite(object):
             assert isinstance(ssprite, sdl2ext.SoftwareSprite)
 
         for factory in (tfactory, sfactory):
-            with pytest.raises((ArgumentError, ValueError)):
+            with pytest.raises(ValueError):
                 factory.from_image(None)
-            #self.assertRaises((IOError, SDLError),
-            #                  factory.from_image, "banana")
-            if not _ISPYPY:
-                with pytest.raises(ArgumentError):
-                    factory.from_image(12345)
+            with pytest.raises(ValueError):
+                factory.from_image(12345)
         dogc()
 
     @pytest.mark.skip("not implemented")


### PR DESCRIPTION
<!--Thanks for contributing to PySDL2!-->

# PR Description

This PR deprecates the `sdl2.ext.load_image` function (which returned inconsistent SDL surface types depending on the back end used), and adds the new functions `sdl2.ext.load_bmp` and `sdl2.ext.load_img` to take its place.

This also adds a new function `sdl2.ext.save_bmp` for saving SDL surfaces as BMP files, as well as another function `sdl2.ext.pillow_to_surface` for converting PIL `Image.Image()` objects into SDL surfaces.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
