### PR TITLE
Rewrite and re-document the BitmapFont class

### DIFF
--- a/doc/modules/ext/bitmapfont.rst
+++ b/doc/modules/ext/bitmapfont.rst
@@ -1,66 +1,8 @@
-Basic Bitmap Font Rendering
-===========================
+`sdl2.ext.bitmapfont` - Basic Bitmap Font Rendering
+===================================================
 
 This module provides the :class:`~sdl2.ext.BitmapFont` class, which allows for
 basic font rendering in PySDL2 without depending on the SDL_ttf library.
 
-
-.. class:: BitmapFont(surface : Sprite, size : iterable[, mapping=None)
-
-   A bitmap graphics to character mapping. The :class:`BitmapFont` class
-   uses an image *surface* to find and render font character glyphs for
-   text. It requires a mapping table, which denotes the characters
-   available on the image.
-
-   The mapping table is a list of strings, where each string reflects a
-   *line* of characters on the image. Each character within each line
-   has the same size as specified by the size argument.
-
-   A typical mapping table might look like ::
-
-      [ '0123456789',
-        'ABCDEFGHIJ',
-        'KLMNOPQRST',
-        'UVWXYZ    ',
-        'abcdefghij',
-        'klmnopqrst',
-        'uvwxyz    ',
-        ',;.:!?+-()' ]
-
-   .. attribute:: surface
-
-      The :class:`sdl2.SDL_Surface` containing the character bitmaps.
-
-   .. attribute:: offsets
-
-      A dict containing the character offsets on the :attr:`surface`.
-
-   .. attribute:: mapping
-
-      The character mapping table, a list of strings.
-
-   .. attribute:: size
-
-      The size of an individual glyph bitmap on the font.
-
-   .. method:: render(text : string[, bpp=None]) -> Sprite
-
-      Renders the passed text on a new :class:`Sprite` and returns it.
-      If no explicit *bpp* are provided, the bpp settings of the
-      :attr:`.surface` are used.
-
-   .. method:: render_on(surface : Sprite, text : string[, \
-                         offset=(0, 0)]) -> (int, int, int, int)
-
-      Renders a text on the passed sprite, starting at a specific
-      offset. The top-left start position of the text will be the
-      passed *offset* and a 4-value tuple with the changed area will be
-      returned.
-
-   .. method:: contains(c : string) -> bool
-
-      Checks, whether a certain character exists in the font.
-
-   .. method:: can_render(text : string) -> bool
-
-      Checks, whether all characters in the passed *text* can be rendered.
+.. automodule:: sdl2.ext.bitmapfont
+	:members:

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -57,6 +57,11 @@ New Features:
   when using SDL2 2.0.10 or newer (PR #207)
 * Added :meth:`sdl2.ext.Renderer.blit` as an alias for the 
   :meth:`sdl2.ext.Renderer.copy` method (PR #207)
+* Added a new method :meth:`~sdl2.ext.BitmapFont.remap` to the
+  :obj:`~sdl2.ext.BitmapFont` class to allow specifying custom character
+  widths and heights for each mapped character in a bitmap font (PR #208)
+* Added a new argument ``line_h`` to :meth:`sdl2.ext.BitmapFont.render_on` to
+  allow specifying custom line heights (PR #208)
 
 Fixed Bugs:
 
@@ -73,6 +78,14 @@ Fixed Bugs:
   try to unlock RLE surfaces once their corresponding view objects are deleted.
   This prevents a segmentation fault when a view is garbage-collected but the
   surface has already been freed (PR #204)
+* Fixed a bug where the rectangle returned by
+  :meth:`sdl2.ext.BitmapFont.render_on` would overestimate the size of the
+  rendered text by one character in both width and height (PR #208)
+* :meth:`sdl2.ext.BitmapFont.contains` no longer assumes that the font map
+  contains a space (PR #208)
+* Rendering multiline text with the :class:`sdl2.ext.BitmapFont` class now
+  always splits lines using the newline (`\n`) character. Previously on
+  Windows, it would only split on Windows-style line endings (`\r\n`) (PR #208)
 
 API Changes:
 
@@ -113,6 +126,11 @@ Deprecation Notices:
   instead (PR #205)
 * The :func:`sdl2.ext.get_image_formats` function has been deprecated, as it
   gives inaccurate results in most cases (PR #205)
+* The :meth:`sdl2.ext.BitmapFont.can_render` method has been deprecated (PR #208)
+* The :meth:`sdl2.ext.BitmapFont.render` method has been deprecated in favor of
+  :meth:`sdl2.ext.BitmapFont.render_text`, which returns an SDL surface instead
+  of a SoftwareSprite and ensures the output surface is in ARGB8888 format by
+  default (PR #208)
 
 
 0.9.9

--- a/sdl2/ext/bitmapfont.py
+++ b/sdl2/ext/bitmapfont.py
@@ -208,6 +208,10 @@ class BitmapFont(object):
         Returns:
             :obj:`~sdl2.SDL_Surface`: A surface containing the rendered text.
 
+        Raises:
+            ValueError: If a character in the text is not provided by the
+            current font.
+
         """
         self._validate_chars(text)
         lines = text.split("\n")
@@ -252,6 +256,10 @@ class BitmapFont(object):
         Returns:
             tuple: The ``(x1, y1, x2, y2)`` rectangle of the target surface on
             which the text was rendered.
+
+        Raises:
+            ValueError: If a character in the text is not provided by the
+            current font.
 
         """
         x1, y1 = offset

--- a/sdl2/ext/bitmapfont.py
+++ b/sdl2/ext/bitmapfont.py
@@ -1,114 +1,180 @@
-import os
-from .. import surface, rect
-from .common import SDLError
+from .. import surface, rect, pixels
+from .common import SDLError, raise_sdl_err
 from .sprite import SoftwareSprite
-from .draw import _get_target_surface
-
+from .surface import _get_target_surface
+from .image import load_bmp
 
 __all__ = ["BitmapFont"]
 
 
 class BitmapFont(object):
-    """A bitmap graphics to character mapping.
+    """A class for rendering text using a given bitmap font.
 
-    The BitmapFont class uses an image surface to find and render font
-    character glyphs for text. It requires a mapping table, which
-    denotes the characters available on the image.
+    This class takes an image of equally-spaced font characters and a font map
+    indicating the location of each character on the image, and uses these to
+    render text using the given font. This class is based on base SDL2 functions
+    and does not require the SDL_ttf library to be installed.
 
-    The mapping table is a list of strings, where each string reflects a
-    'line' of characters on the image. Each character within each line
-    has the same size as specified by the size argument.
+    The font mapping table is a list of strings, with each string representing
+    a row of characters on the font image surface. Each character within each
+    line is assumed to be of equal height and width, but this can be adjusted
+    using the :meth:`remap` method.
+    
+    For example, the built-in bitmap font ``font.bmp`` has the following layout:
 
-    A typical mapping table might look like
+    .. image:: images/font.png
 
-      [ '0123456789',
-        'ABCDEFGHIJ',
-        'KLMNOPQRST',
-        'UVWXYZ    ',
-        'abcdefghij',
-        'klmnopqrst',
-        'uvwxyz    ',
-        ',;.:!?+-()' ]
+    The default font mapping table, which matches the layout of ``font.bmp``,
+    looks like this::
+
+       fontmap = [
+           '0123456789',
+           'ABCDEFGHIJ',
+           'KLMNOPQRST',
+           'UVWXYZ    ',
+           'abcdefghij',
+           'klmnopqrst',
+           'uvwxyz    ',
+           ',;.:!?+-()',
+        ]
+    
+    Args:
+        font_img (:obj:`SDL_Surface` or str): A surface or path to a file
+            containing a valid bitmap (``.bmp``) font image.
+        size (tuple, optional): A ``(width, height)`` tuple defining the size of
+            each character in the bitmap font. If not specified, this will be
+            inferred automatically from the fontmap and font image.
+        fontmap (list, optional): A list of strings defining the locations of
+            characters in the font image. If not specified, the default font map
+            defined above will be used.
+
     """
+    DEFAULTMAP = [
+        "0123456789",
+        "ABCDEFGHIJ",
+        "KLMNOPQRST",
+        "UVWXYZ    ",
+        "abcdefghij",
+        "klmnopqrst",
+        "uvwxyz    ",
+        ",;.:!?+-()",
+    ]
 
-    DEFAULTMAP = ["0123456789",
-                  "ABCDEFGHIJ",
-                  "KLMNOPQRST",
-                  "UVWXYZ    ",
-                  "abcdefghij",
-                  "klmnopqrst",
-                  "uvwxyz    ",
-                  ",;.:!?+-()"
-                ]
+    def __init__(self, font_img, size=None, mapping=None):
+        if hasattr(font_img, "upper"):  # if string
+            self.surface = load_bmp(font_img)
+        elif isinstance(font_img, SoftwareSprite):
+            self.surface = font_img.surface
+            self._sprite = font_img  # prevent GC on the Sprite
+        elif isinstance(font_img, surface.SDL_Surface):
+            self.surface = font_img
+        elif "SDL_Surface" in str(type(font_img)):
+            self.surface = font_img.contents
+        else:
+            raise TypeError("font_img must be a Sprite or SDL_Surface")
 
-
-    def __init__(self, imgsurface, size, mapping=None):
-        """Creates a new BitmapFont instance from the passed image.
-
-        Each character is expected to be of the same size (a 2-value tuple
-        denoting the width and height) and to be in order of the passed
-        mapping.
-        """
         if mapping is None:
             self.mapping = list(BitmapFont.DEFAULTMAP)
         else:
             self.mapping = mapping
-        self.offsets = {}
-        if isinstance(imgsurface, SoftwareSprite):
-            self.surface = imgsurface.surface
-            self._sprite = imgsurface # prevent GC on the Sprite
-        elif isinstance(imgsurface, surface.SDL_Surface):
-            self.surface = imgsurface
-        elif "SDL_Surface" in str(type(imgsurface)):
-            self.surface = imgsurface.contents
-        else:
-            raise TypeError("imgsurface must be a Sprite or SDL_Surface")
+
+        if not size:
+            map_rows = len(self.mapping)
+            map_cols = len(self.mapping[0])
+            surf_size = (float(self.surface.w), float(self.surface.h))
+            size = (int(surf_size[0] / map_cols), int(surf_size[1] / map_rows))
         self.size = size[0], size[1]
+
+        self.offsets = {}
+        self._max_height = self.size[1]
         self._calculate_offsets()
 
     def _calculate_offsets(self):
-        """Calculates the internal character offsets for each line."""
+        # Calculates the internal character offsets for each line
         self.offsets = {}
-        offsets = self.offsets
         x, y = 0, 0
         w, h = self.size
         for line in self.mapping:
             x = 0
             for c in line:
-                offsets[c] = rect.SDL_Rect(x, y, w, h)
+                if c not in self.offsets.keys():
+                    self.offsets[c] = rect.SDL_Rect(x, y, w, h)
                 x += w
             y += h
 
     def _validate_chars(self, text):
         e = "The character '{0}' does not exist within the current font mapping"
         for ch in text:
-            if ch not in self.offsets.keys():
+            if ch != "\n" and ch not in self.offsets.keys():
                 raise ValueError(e.format(ch))
 
-    def _render_text(self, target, fontsf, lines, offset=(0, 0)):
-        w, h = self.size
+    def _get_rendered_size(self, text, line_h):
+        line_h = self._max_height if not line_h else line_h
+        text_w, text_h = (0, 0)
+        lines = text.split("\n")
+        for line in lines:
+            line_w = 0
+            for c in line:
+                charsize = self.offsets[c]
+                line_w += charsize.w
+            if line_w > text_w:
+                text_w = line_w
+            text_h += line_h
+        return (text_w, text_h)
+
+    def _render_text(self, target, fontsf, lines, line_h, offset=(0, 0)):
+        line_h = self._max_height if not line_h else line_h
         dstr = rect.SDL_Rect(0, 0, 0, 0)
         y = offset[1]
         for line in lines:
-            dstr.y = y
             x = offset[0]
             for c in line:
                 dstr.x = x
+                dstr.y = y + (line_h - self.offsets[c].h)
                 surface.SDL_BlitSurface(fontsf, self.offsets[c], target, dstr)
-                x += w
-            y += h
+                x += self.offsets[c].w
+            y += line_h
         return (x, y)
 
-    def render(self, text, bpp=None):
-        """Renders the passed text on a new Sprite and returns it."""
-        w, h = self.size
-        self._validate_chars(text)
-        lines = text.split(os.linesep)
+    def remap(self, c, x, y, w, h):
+        """Updates the source rectangle for a given font character.
 
-        tw, th = 0, 0
-        for line in lines:
-            tw = max(tw, sum([w for c in line]))
-            th += h
+        This method can be used to fine-tune the character mappings in the font
+        image to produce better spacing in the rendered text.
+
+        Args:
+            c (str): The character to remap in the font image.
+            x (int): The x coordinate (in pixels) of the top-left corner of the
+                new rectangle for the character.
+            y (int): The y coordinate (in pixels) of the top-left corner of the
+                new rectangle for the character.
+            w (int): The width (in pixels) of the new rectangle for the
+                character.
+            h (int): The height (in pixels) of the new rectangle for the
+                character.
+
+        """
+        if len(c) > 1:
+            raise ValueError("Can only remap one character at a time.")
+        self._validate_chars(c)
+        x, y, w, h = [int(i) for i in (x, y, w, h)]
+        if any([w < 1, h < 1]):
+            raise ValueError("Width and height must both be positive integers.")
+        surf_w, surf_h = (self.surface.w, self.surface.h)
+        if x < 0 or y < 0 or x+w >= surf_w or y+h >= surf_h:
+            e = "Character rectangle cannot exceed the bounds of the font image"
+            raise ValueError(e + " ({0}, {1}).".format(surf_w, surf_h))
+
+        self.offsets[c] = rect.SDL_Rect(x, y, w, h)
+        if h > self._max_height:
+            self._max_height = h
+
+    def render(self, text, bpp=None):
+        # Deprecated: replaced by render_text, which returns a surface
+        self._validate_chars(text)
+        lines = text.split("\n")
+
+        tw, th = self._get_rendered_size(text, None)
         if bpp is None:
             bpp = self.surface.format.contents.BitsPerPixel
         sf = surface.SDL_CreateRGBSurface(0, tw, th, bpp, 0, 0, 0, 0)
@@ -116,32 +182,105 @@ class BitmapFont(object):
             raise SDLError()
         imgsurface = SoftwareSprite(sf.contents, False)
 
-        self._render_text(imgsurface.surface, self.surface, lines)
+        self._render_text(imgsurface.surface, self.surface, lines, None)
         return imgsurface
 
-    def render_on(self, imgsurface, text, offset=(0, 0)):
-        """Renders a text on the passed sprite, starting at a specific
-        offset.
+    def render_text(self, text, line_h=None, as_argb=True):
+        """Renders a string of text to a new surface.
 
-        The top-left start position of the text will be the passed offset and
-        4-value tuple with the changed area will be returned.
+        If a newline character (``\\n``) is encountered in the string, it will
+        be rendered as a line break in the rendered text.
+
+        By default, this function also converts the rendered text from the native
+        format of the font image to 32-bit ARGB, for consistency across functions
+        and better compatibility with SDL2 renderers. To disable ARGB conversion,
+        set the ``as_argb`` parameter to ``False``.
+
+        Args:
+            text (str): The string of text to render.
+            line_h (int, optional): The line height (in pixels) to use for each
+                line of the rendered text. If not specified, the maximum
+                character height for the font will be used. Defaults to ``None``.
+            as_argb (bool, optional): Whether the output surface should be
+                converted to 32-bit ARGB pixel format or left as-is. Defaults to
+                ``True`` (convert to ARGB).
+
+        Returns:
+            :obj:`~sdl2.SDL_Surface`: A surface containing the rendered text.
+
         """
-        w, h = self.size
-        target = _get_target_surface(imgsurface)
         self._validate_chars(text)
-        lines = text.split(os.linesep)
+        lines = text.split("\n")
 
-        x, y = self._render_text(target, self.surface, lines, offset)
-        return (offset[0], offset[1], x + w, y + h)
+        # Create a new surface with the same format as the font image
+        tw, th = self._get_rendered_size(text, line_h)
+        fmt = self.surface.format.contents.format
+        bpp = 32  # according to SDL2 source, this has no effect
+        sf = surface.SDL_CreateRGBSurfaceWithFormat(0, tw, th, bpp, fmt)
+        if not sf:
+            raise_sdl_err("creating the font surface")
+
+        # Render text to the new surface, converting pixel format if necessary
+        self._render_text(sf.contents, self.surface, lines, line_h)
+        if as_argb and fmt != pixels.SDL_PIXELFORMAT_ARGB8888:
+            out_fmt = pixels.SDL_AllocFormat(pixels.SDL_PIXELFORMAT_ARGB8888)
+            sf_argb = surface.SDL_ConvertSurface(sf, out_fmt, 0)
+            surface.SDL_FreeSurface(sf)
+            sf = sf_argb
+            if not sf:
+                raise_sdl_err("converting rendered text to ARGB format")
+
+        return sf.contents
+
+    def render_on(self, target, text, offset=(0, 0), line_h=None):
+        """Renders a string of text to an existing surface.
+
+        If a newline character (``\\n``) is encountered in the string, it will
+        be rendered as a line break in the rendered text.
+
+        Args:
+            target (:obj:`~sdl2.SDL_Surface`): The surface on which to render
+                the given string.
+            text (str): The string of text to render to the target surface.
+            offset (tuple, optional): The ``(x, y)`` coordinates of the target
+                surface on which the top-left corner of the rendered text will
+                be placed. Defaults to ``(0, 0)``.
+            line_h (int, optional): The line height (in pixels) to use for each
+                line of the rendered text. If not specified, the maximum
+                character height for the font will be used. Defaults to ``None``.
+
+        Returns:
+            tuple: The ``(x1, y1, x2, y2)`` rectangle of the target surface on
+            which the text was rendered.
+
+        """
+        x1, y1 = offset
+        dest = rect.SDL_Rect(x1, y1, 0, 0)
+        target = _get_target_surface(target)
+
+        sf = self.render_text(text, line_h, as_argb=False)
+        ret = surface.SDL_BlitSurface(sf, None, target, dest)
+        if ret != 0:
+            raise_sdl_err("copying the text to the target surface")
+
+        return (x1, y1, x1 + sf.w, y1 + sf.h)
 
     def contains(self, c):
-        """Checks, whether a certain character exists in the font."""
-        return c == ' ' or c in self.offsets
+        """Checks whether a given character is mapped within the font.
+        
+        Args:
+            c (str): The character to check for within the font map.
+
+        Returns:
+            bool: ``True`` if the font contains the character, otherwise
+            ``False``.
+    
+        """
+        return c in self.offsets
 
     def can_render(self, text):
-        """Checks, whether all characters in the passed text can be rendered.
-        """
-        lines = text.split(os.linesep)
+        # Deprecated: already throws informative exception on missing character
+        lines = text.split("\n")
         for line in lines:
             for c in line:
                 if c != ' ' and c not in self.offsets:

--- a/sdl2/test/sdl2ext_font_test.py
+++ b/sdl2/test/sdl2ext_font_test.py
@@ -3,9 +3,14 @@ import pytest
 from sdl2 import ext as sdl2ext
 from sdl2.ext.compat import byteify
 from sdl2.ext.pixelaccess import pixels2d
-from sdl2 import surface
+from sdl2.ext.surface import _create_surface
+from sdl2 import surface, pixels, SDL_ClearError
 
-sdlttf = pytest.importorskip("sdl2.sdlttf")
+_HASSDLTTF = True
+try:
+    from .. import sdlttf
+except ImportError:
+    _HASSDLTTF = False
 
 
 RESOURCES = sdl2ext.Resources(__file__, "resources")
@@ -20,7 +25,7 @@ FONTMAP = ["0123456789",
            ]
 
 
-class TestSDL2ExtFont(object):
+class TestBitmapFont(object):
     __tags__ = ["sdl", "sdl2ext"]
 
     @classmethod
@@ -34,7 +39,10 @@ class TestSDL2ExtFont(object):
     def teardown_class(cls):
         sdl2ext.quit()
 
-    def test_BitmapFont(self):
+    def setup_method(self):
+        SDL_ClearError()
+
+    def test_init(self):
         # Initialize surface and sprite for tests
         fontpath = byteify(RESOURCES.get_path("font.bmp"), "utf-8")
         sf = surface.SDL_LoadBMP(fontpath)
@@ -52,11 +60,19 @@ class TestSDL2ExtFont(object):
         font = sdl2ext.BitmapFont(sf, (32, 32), FONTMAP)
         assert font.size == (32, 32)
 
+        # Try loading a font directly from a .bmp
+        font = sdl2ext.BitmapFont(fontpath, (32, 32), FONTMAP)
+        assert font.size == (32, 32)
+
+        # Test use of default fontmap and inferred character size
+        font = sdl2ext.BitmapFont(sf)
+        assert font.size == (32, 32)
+
         # Try invalid surface type
         with pytest.raises(TypeError):
-            font = sdl2ext.BitmapFont("hello", (32, 32), FONTMAP)
+            sdl2ext.BitmapFont([], (32, 32), FONTMAP)
 
-    def test_BitmapFont_render(self):
+    def test_render(self):
         # Initialize font and BitmapFont for tests
         fontpath = byteify(RESOURCES.get_path("font.bmp"), "utf-8")
         sf = surface.SDL_LoadBMP(fontpath)
@@ -72,44 +88,119 @@ class TestSDL2ExtFont(object):
         with pytest.raises(ValueError):
             font.render("this_should_fail")
 
-    def test_BitmapFont_render_on(self):
-        np = pytest.importorskip("numpy", reason="numpy module is not available")
-        # Initialize font, surface, and BitmapFont for tests
+    def test_render_text(self):
+        # Initialize BitmapFont and dummy RGB888 surface for tests
         fontpath = byteify(RESOURCES.get_path("font.bmp"), "utf-8")
-        sf = surface.SDL_LoadBMP(fontpath)
-        font = sdl2ext.BitmapFont(sf.contents, (32, 32), FONTMAP)
+        font = sdl2ext.BitmapFont(fontpath)
+        rgb_surf = _create_surface(size=(320, 256), fmt="RGB888")
+        font_rgb = sdl2ext.BitmapFont(rgb_surf)
 
         # Try rendering some text
-        target = surface.SDL_CreateRGBSurface(0, 32*5, 32, 32, 0, 0, 0, 0)
+        msg = "hello there!"
+        text = font.render_text(msg)
+        assert isinstance(text, surface.SDL_Surface)
+        assert text.w == 32 * len(msg)
+        assert text.h == 32
+        surface.SDL_FreeSurface(text)
+
+        # Try rendering with a different line height
+        text = font.render_text(msg, line_h=40)
+        assert isinstance(text, surface.SDL_Surface)
+        assert text.w == 32 * len(msg)
+        assert text.h == 40
+        surface.SDL_FreeSurface(text)
+
+        # Make sure ARGB converion works
+        text = font_rgb.render_text(msg)
+        assert isinstance(text, surface.SDL_Surface)
+        assert text.w == 32 * len(msg)
+        assert text.h == 32
+        assert text.format.contents.format == pixels.SDL_PIXELFORMAT_ARGB8888
+        surface.SDL_FreeSurface(text)
+
+        # Try rendering without ARGB conversion
+        text = font_rgb.render_text(msg, as_argb=False)
+        assert isinstance(text, surface.SDL_Surface)
+        assert text.w == 32 * len(msg)
+        assert text.h == 32
+        assert text.format.contents.format == pixels.SDL_PIXELFORMAT_RGB888
+        surface.SDL_FreeSurface(text)
+
+        # Test multiline rendering
+        msg = "hello\nthere!"
+        text = font.render_text(msg)
+        assert isinstance(text, surface.SDL_Surface)
+        assert text.w == 32 * 6
+        assert text.h == 64
+        surface.SDL_FreeSurface(text)
+
+        # Test exception for missing glyph
+        with pytest.raises(ValueError):
+            font.render_text("this_should_fail")
+
+    def test_render_on(self):
+        np = pytest.importorskip("numpy", reason="numpy module is not available")
+        # Initialize BitmapFont for tests
+        fontpath = byteify(RESOURCES.get_path("font.bmp"), "utf-8")
+        font = sdl2ext.BitmapFont(fontpath)
+
+        # Try rendering some text
+        target = _create_surface(size=(32*5, 32))
         view = pixels2d(target, transpose=False)
         mid_row = view[16, :].copy()
-        font.render_on(target, "TEST!")
+        outrect = font.render_on(target, "TEST!")
         assert not np.all(mid_row == view[16, :]) # ensure surface changed
+        assert outrect == (0, 0, 32*5, 32)
 
         # Try rendering some text with an offset
-        target2 = surface.SDL_CreateRGBSurface(0, 32*5, 32, 32, 0, 0, 0, 0)
+        target2 = _create_surface(size=(32*5, 32))
         view2 = pixels2d(target2, transpose=False)
-        font.render_on(target2, "TEST!", offset=(5, 0))
+        outrect2 = font.render_on(target2, "TEST!", offset=(5, 0))
         assert not np.all(mid_row == view2[16, :]) # ensure surface changed
         assert not np.all(view[16, :] == view2[16, :]) # ensure offset worked
+        assert outrect2 == (5, 0, 32*5 + 5, 32)
+
+        surface.SDL_FreeSurface(target)
+        surface.SDL_FreeSurface(target2)
 
         # Test exception for missing glyph
         with pytest.raises(ValueError):
             font.render_on(target, "%nope")
 
-    def test_BitmapFont_contains(self):
-        sf = surface.SDL_LoadBMP(byteify(RESOURCES.get_path("font.bmp"),
-                                         "utf-8"))
-        assert isinstance(sf.contents, surface.SDL_Surface)
-        font = sdl2ext.BitmapFont(sf, (32, 32), FONTMAP)
-        assert isinstance(font, sdl2ext.BitmapFont)
+    def test_remap(self):
+        # Initialize BitmapFont for tests
+        fontpath = byteify(RESOURCES.get_path("font.bmp"), "utf-8")
+        font = sdl2ext.BitmapFont(fontpath)
+        msg = "hello there!"
+
+        # Remap the l to be narrower and try rendering
+        font.remap("l", 32, 160, 12, 32)
+        text = font.render_text(msg)
+        assert text.w == (32 * len(msg) - 40)
+        assert text.h == 32
+
+        surface.SDL_FreeSurface(text)
+
+        # Test exceptions on bad input
+        with pytest.raises(ValueError):
+            font.remap("hi", 4, 4, 4, 4)
+        with pytest.raises(ValueError):
+            font.remap("h", 10, 32, 32, 0)
+        with pytest.raises(ValueError):
+            font.remap("h", 32, 1000, 32, 32)
+
+    def test_contains(self):
+        # Initialize BitmapFont for tests
+        fontpath = byteify(RESOURCES.get_path("font.bmp"), "utf-8")
+        font = sdl2ext.BitmapFont(fontpath)
 
         for ch in "abcde12345.-,+":
             assert font.contains(ch)
-        for ch in "äöüß":
+        del font.offsets[" "]
+        for ch in u" äöüß":
             assert not font.contains(ch)
 
-    def test_BitmapFont_can_render(self):
+    def test_can_render(self):
         sf = surface.SDL_LoadBMP(byteify(RESOURCES.get_path("font.bmp"),
                                          "utf-8"))
         assert isinstance(sf.contents, surface.SDL_Surface)
@@ -120,7 +211,27 @@ class TestSDL2ExtFont(object):
         assert font.can_render("473285435hfsjadfhriuewtrhefd")
         assert not font.can_render("testä")
 
-    def test_FontManager(self):
+
+
+@pytest.mark.skipif(not _HASSDLTTF, reason="SDL_TTF library not available")
+class TestFontManager(object):
+    __tags__ = ["sdl", "sdl2ext"]
+
+    @classmethod
+    def setup_class(cls):
+        try:
+            sdl2ext.init()
+        except sdl2ext.SDLError:
+            raise pytest.skip('Video subsystem not supported')
+
+    @classmethod
+    def teardown_class(cls):
+        sdl2ext.quit()
+
+    def setup_method(self):
+        SDL_ClearError()
+
+    def test_init(self):
         fm = sdl2ext.FontManager(RESOURCES.get_path("tuffy.ttf"),
                                  bg_color=(100, 0, 0))
         assert isinstance(fm, sdl2ext.FontManager)
@@ -128,7 +239,7 @@ class TestSDL2ExtFont(object):
         assert fm.size == 16
         assert fm.bg_color == sdl2ext.Color(100, 0, 0, 0)
 
-    def test_FontManager_default_font(self):
+    def test_default_font(self):
         fm = sdl2ext.FontManager(RESOURCES.get_path("tuffy.ttf"))
         assert fm.default_font == "tuffy"
         assert fm.size == 16
@@ -144,7 +255,7 @@ class TestSDL2ExtFont(object):
         assert fm.default_font == "tuffy.copy"
         assert fm.size == 16
 
-    def test_FontManager_add(self):
+    def test_add(self):
         fm = sdl2ext.FontManager(RESOURCES.get_path("tuffy.ttf"))
         assert "tuffy" in fm.aliases
         assert "tuffy" in fm.fonts
@@ -171,7 +282,7 @@ class TestSDL2ExtFont(object):
         fm.add(RESOURCES.get_path("tuffy.ttf"), size=12)
         assert isinstance(fm.fonts["tuffy"][12].contents, sdlttf.TTF_Font)
 
-    def test_FontManager_close(self):
+    def test_close(self):
         fm = sdl2ext.FontManager(RESOURCES.get_path("tuffy.ttf"))
         fm.add(RESOURCES.get_path("tuffy.ttf"), size=20)
         fm.add(RESOURCES.get_path("tuffy.ttf"), alias="Foo", size=10)
@@ -179,7 +290,7 @@ class TestSDL2ExtFont(object):
         assert fm.fonts == {}
         # How to make sure TTF_CloseFont was called on each loaded font?
 
-    def test_FontManager_render(self):
+    def test_render(self):
         fm = sdl2ext.FontManager(RESOURCES.get_path("tuffy.ttf"))
         text_surf = fm.render("text")
         assert isinstance(text_surf, surface.SDL_Surface)


### PR DESCRIPTION
<!--Thanks for contributing to PySDL2!-->

# PR Description

This PR rewrites and re-documents the `sdl.ext.BitmapFont` class, fixing a wide range of bugs and API unpleasantness. The main new additions are the `render_text` method, which renders text to an SDL surface (converted to ARGB8888 format by default) and supports custom line heights, and a :meth:`remap` method for customizing the surface-to-character mappings and fine-tuning character sizes (e.g. making the "i" character narrower than the "o" character).

Additionally, this PR deprecates the  `render` method as it returns a `SoftwareSprite` instead of a regular `SDL_Surface` (now replaced by `render_text`), as well as the `can_render` method which is no longer useful (`render_text` and `render_on` already throw an informative exception on a missing character).

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
