### PR TITLE
sdlttf_test: Accept width and height within a range

### DIFF
--- a/sdl2/test/sdlttf_test.py
+++ b/sdl2/test/sdlttf_test.py
@@ -220,41 +220,39 @@ class TestSDLTTF(object):
 
     def test_TTF_SizeText(self):
         font = sdlttf.TTF_OpenFont(fontfile, 20)
-        expected_w = 70
-        expected_h = [
-            25, # SDL2_ttf < 2.0.15
-            24, # SDL2_ttf == 2.0.15 w/ FreeType 2.9.1
-            21  # SDL2_ttf == 2.0.15 w/ FreeType 2.10.1
-        ]
+        min_expected_w = 69     # SDL2_ttf 2.0.18
+        max_expected_w = 70     # SDL2_ttf <= 2.0.15
+        min_expected_h = 21     # SDL2_ttf 2.0.15 with FreeType 2.10.1
+        max_expected_h = 25     # SDL2_ttf < 2.0.15
         w, h = c_int(0), c_int(0)
         sdlttf.TTF_SizeText(font, b"Hi there!", byref(w), byref(h))
-        assert w.value == expected_w
-        assert h.value in expected_h
+        assert w.value >= min_expected_w
+        assert w.value <= max_expected_w
+        assert h.value >= min_expected_h
+        assert h.value <= max_expected_h
         sdlttf.TTF_CloseFont(font)
 
     def test_TTF_SizeUTF8(self):
         font = sdlttf.TTF_OpenFont(fontfile, 20)
-        expected_w = 73
-        expected_h = [
-            25, # SDL2_ttf < 2.0.15
-            24, # SDL2_ttf == 2.0.15 w/ FreeType 2.9.1
-            21  # SDL2_ttf == 2.0.15 w/ FreeType 2.10.1
-        ]
+        min_expected_w = 72     # SDL2_ttf 2.0.18
+        max_expected_w = 73     # SDL2_ttf <= 2.0.15
+        min_expected_h = 21     # SDL2_ttf 2.0.15 with FreeType 2.10.1
+        max_expected_h = 25     # SDL2_ttf < 2.0.15
         w, h = c_int(0), c_int(0)
         sdlttf.TTF_SizeUTF8(font, u"Hï thère!".encode('utf-8'), byref(w), byref(h))
-        assert w.value == expected_w
-        assert h.value in expected_h
+        assert w.value >= min_expected_w
+        assert w.value <= max_expected_w
+        assert h.value >= min_expected_h
+        assert h.value <= max_expected_h
         sdlttf.TTF_CloseFont(font)
 
     @pytest.mark.xfail(reason="Highly unstable under pytest for some reason")
     def test_TTF_SizeUNICODE(self):
         font = sdlttf.TTF_OpenFont(fontfile, 20)
-        expected_w = 70
-        expected_h = [
-            25, # SDL2_ttf < 2.0.15
-            24, # SDL2_ttf == 2.0.15 w/ FreeType 2.9.1
-            21  # SDL2_ttf == 2.0.15 w/ FreeType 2.10.1
-        ]
+        min_expected_w = 69     # SDL2_ttf 2.0.18
+        max_expected_w = 70     # SDL2_ttf <= 2.0.15
+        min_expected_h = 21     # SDL2_ttf 2.0.15 with FreeType 2.10.1
+        max_expected_h = 25     # SDL2_ttf < 2.0.15
         w, h = c_int(0), c_int(0)
         teststr = u"Hi there!"
         strlen = len(teststr) + 1 # +1 for byte-order mark
@@ -263,8 +261,10 @@ class TestSDLTTF(object):
         sdlttf.TTF_SizeUNICODE(font, strarr, byref(w), byref(h))
         print(list(strarr))
         print("w = {0}, h = {1}".format(w.value, h.value))
-        assert w.value == expected_w
-        assert h.value in expected_h
+        assert w.value >= min_expected_w
+        assert w.value <= max_expected_w
+        assert h.value >= min_expected_h
+        assert h.value <= max_expected_h
         sdlttf.TTF_CloseFont(font)
 
     def test_TTF_Render_Solid(self):


### PR DESCRIPTION
# PR Description

SDL2_ttf 2.0.18 with Harfbuzz-based font rendering gives a width
slightly narrower than 2.0.15, so tolerate that.

Previously the height was not allowed to be 22 or 23, but if 21 and 25
are both acceptable values, then anything in between also seems fine;
for better future-proofing, accept a range.

Resolves: https://github.com/marcusva/py-sdl2/issues/212

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
